### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ One example for a recently created comment model would be:
 An example for a model that was updated:
 
 ```blade
-<turbo-stream target="comment_123" action="update">
+<turbo-stream target="comment_123" action="replace">
   <template>
     @include('comments._comment', ['comment' => $comment])
   </template>


### PR DESCRIPTION
According to this explanation:
> If the model was updated, the `target` of the Turbo Stream tag will be the DOM ID of the model itself (using the `@domid()` helper's conventions), and the default `action` will be `replace`.

And this code: https://github.com/tonysm/turbo-laravel/blob/0.1.2/src/TurboStreamResponseMacro.php#L57

This README section is wrong:
>An example for a model that was updated:
```blade
<turbo-stream target="comment_123" action="update">
  <template>
    @include('comments._comment', ['comment' => $comment])
  </template>
</turbo-stream>
```

I'll be a `replace` action, not an `update` action, or maybe I miss something 🤔

If the `replace` action isn't what you need, in your controller, you can do something like below, it'll generated the desired Turbo Stream `update` action:
```php
  return response()->turboStream($comment, 'update');
```

You can see the default action is `replace` and not `update`, when updating a comment of a post with the excellent demo app: https://turbo-laravel.tonysm.com/posts

Here the PHP code: https://github.com/tonysm/turbo-demo-app/blob/e1c0502545234454733671e590703461bf154c18/app/Http/Controllers/CommentsController.php#L36

And here the HTML response of an updating comment:
```html
<turbo-stream target="comment_999" action="replace">
    <template>
        <turbo-frame id="comment_999">
            <div class="bg-white p-4 rounded shadow my-4">
            ...
            </div>
        </turbo-frame>
    </template>
</turbo-stream>
```