### PR TITLE
Handle soft-deletes as regular deletes for Turbo Stream

### DIFF
--- a/src/TurboStreamResponseMacro.php
+++ b/src/TurboStreamResponseMacro.php
@@ -16,7 +16,9 @@ class TurboStreamResponseMacro
 
     public function handle(Model $model, string $action = null)
     {
-        if (! $model->exists) {
+        if (! $model->exists ||
+            (method_exists($model, 'trashed') && $model->trashed())
+        ) {
             return $this->renderModelDeletedStream($model);
         }
 

--- a/tests/Http/ResponseMacrosTest.php
+++ b/tests/Http/ResponseMacrosTest.php
@@ -2,6 +2,7 @@
 
 namespace Tonysm\TurboLaravel\Tests\Http;
 
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\View;
 use Tonysm\TurboLaravel\Models\Broadcasts;
 use Tonysm\TurboLaravel\Tests\TestCase;
@@ -112,6 +113,21 @@ html;
     }
 
     /** @test */
+    public function streams_model_on_soft_delete()
+    {
+        $testModelSoftDelete = tap(TestModelSoftDelete::create(['name' => 'test']))->delete();
+
+        $expected = <<<html
+<turbo-stream target="test_model_soft_delete_{$testModelSoftDelete->getKey()}" action="remove"></turbo-stream>
+html;
+
+        $resp = response()->turboStream($testModelSoftDelete);
+
+        $this->assertEquals($expected, trim($resp->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $resp->headers->get('Content-Type'));
+    }
+
+    /** @test */
     public function streams_broadcastable_models_for_deleted()
     {
         $testModel = BroadcastTestModel::withoutEvents(function () {
@@ -187,6 +203,16 @@ class TestModel extends \Tonysm\TurboLaravel\Tests\TestModel
     public function hotwirePartialName()
     {
         return "_test_model";
+    }
+}
+
+class TestModelSoftDelete extends TestModel
+{
+    use SoftDeletes;
+
+    public function hotwirePartialName()
+    {
+        return "_test_model_soft_delete";
     }
 }
 

--- a/tests/Stubs/views/_test_model_soft_delete.blade.php
+++ b/tests/Stubs/views/_test_model_soft_delete.blade.php
@@ -1,0 +1,1 @@
+<div id="@domid($testModelSoftDelete)">hello</div>


### PR DESCRIPTION
Hi @tonysm,

I don't think soft-deletes are handle as regular deletes right now for default Turbo Stream.

According to this line: https://github.com/tonysm/turbo-laravel/blob/0.3.2/src/TurboStreamResponseMacro.php#L19

You check if the model exists, but a soft deleted model response to `true` on this `exists` attribute.

In this pull request I add the fix below and a corresponding test:
```php

        if (! $model->exists ||
             (method_exists($model, 'trashed') && $model->trashed())
        ) {
            return $this->renderModelDeletedStream($model);
        }
```

If you remove my fix, the new test will failed with this error:
```
There was 1 failure:

1) Tonysm\TurboLaravel\Tests\Http\ResponseMacrosTest::streams_model_on_soft_delete
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'<turbo-stream target="test_model_soft_delete_1" action="remove"></turbo-stream>'
+'<turbo-stream target="test_model_soft_deletes" action="append">\n
+    <template>\n
+        <div id="test_model_soft_delete_1">hello</div>\n
+    </template>\n
+</turbo-stream>'

/home/username/turbo-laravel/tests/Http/ResponseMacrosTest.php:126
```

Reference:
https://github.com/tonysm/turbo-laravel/issues/5#issuecomment-801160342

Have a good day,
Tortue Torche