### PR TITLE
Upgrade to Laravel ^8.46

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,7 +760,7 @@ class CreatesCommentsTest extends TestCase
 
         Bus::assertDispatched(function (BroadcastAction $job) use($post) {
             return count($job->channels) === 1
-                && $job->channels[0]->name === $post->broadcastChannel()
+                && $job->channels[0]->name === sprintf('private-%s', $post->broadcastChannel())
                 && $job->target === 'comments'
                 && $job->action === 'append'
                 && $job->partial === 'comments._comment'

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "illuminate/support": "^8.0"
+        "illuminate/support": "^8.46"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0",

--- a/src/Broadcasters/LaravelBroadcaster.php
+++ b/src/Broadcasters/LaravelBroadcaster.php
@@ -37,7 +37,7 @@ class LaravelBroadcaster implements Broadcaster
         if ($later) {
             dispatch($job);
         } else {
-            dispatch_now($job);
+            dispatch_sync($job);
         }
     }
 }

--- a/src/Broadcasting/PendingBroadcast.php
+++ b/src/Broadcasting/PendingBroadcast.php
@@ -2,9 +2,9 @@
 
 namespace Tonysm\TurboLaravel\Broadcasting;
 
-use Broadcast;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Broadcast;
 use Tonysm\TurboLaravel\Facades\Turbo;
 
 class PendingBroadcast

--- a/src/Models/Broadcasts.php
+++ b/src/Models/Broadcasts.php
@@ -11,8 +11,6 @@ use function Tonysm\TurboLaravel\dom_id;
 use Tonysm\TurboLaravel\Models\Naming\Name;
 use Tonysm\TurboLaravel\NamesResolver;
 
-use Tonysm\TurboLaravel\Views\RecordIdentifier;
-
 /**
  * @mixin \Illuminate\Database\Eloquent\Model
  */
@@ -130,7 +128,7 @@ trait Broadcasts
             }
 
             return new PrivateChannel(
-                (new RecordIdentifier($streamable))->channelName()
+                $streamable->broadcastChannel()
             );
         })->values()->all();
     }

--- a/src/NamesResolver.php
+++ b/src/NamesResolver.php
@@ -22,12 +22,4 @@ class NamesResolver
 
         return "{$resource}._{$partial}";
     }
-
-    public function broadcastingChannelForModel(Model $model)
-    {
-        // Converts the name path to a dot-notation. So "App\\Models\\Task" becomes "App.Models.Task"
-        $path = str_replace('\\', '.', get_class($model));
-
-        return "{$path}.{$model->getKey()}";
-    }
 }

--- a/src/TurboServiceProvider.php
+++ b/src/TurboServiceProvider.php
@@ -67,7 +67,7 @@ class TurboServiceProvider extends ServiceProvider
         });
 
         Blade::directive('channel', function ($expression) {
-            return "<?php echo e(\\Tonysm\\TurboLaravel\\turbo_channel($expression)); ?>";
+            return "<?php echo {$expression}->broadcastChannel(); ?>";
         });
     }
 

--- a/src/Views/RecordIdentifier.php
+++ b/src/Views/RecordIdentifier.php
@@ -34,16 +34,4 @@ class RecordIdentifier
 
         return trim("{$prefix}{$delimiter}{$singular}", $delimiter);
     }
-
-    public function channelName(): string
-    {
-        return static::channelAuthKey(get_class($this->record), $this->record->getKey());
-    }
-
-    public static function channelAuthKey(string $className, string $key): string
-    {
-        $path = str_replace('\\', '.', $className);
-
-        return "{$path}.{$key}";
-    }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -29,27 +29,3 @@ function dom_class(Model $model, string $prefix = ""): string
 {
     return (new RecordIdentifier($model))->domClass($prefix);
 }
-
-/**
- * Generates the channel name for a given model, using its key (identifier).
- *
- * @param Model $model
- * @return string
- */
-function turbo_channel(Model $model): string
-{
-    return turbo_channel_auth(get_class($model), $model->getKey());
-}
-
-/**
- * Generates the channel auth key to be used when registering the Broadcasting
- * Channel for a model class and wil.
- *
- * @param string $className
- * @param string|null $wildcard
- * @return string
- */
-function turbo_channel_auth(string $className, string $wildcard = null): string
-{
-    return RecordIdentifier::channelAuthKey($className, $wildcard ?: "{id}");
-}

--- a/tests/Models/BroadcastsModelTest.php
+++ b/tests/Models/BroadcastsModelTest.php
@@ -9,8 +9,6 @@ use Tonysm\TurboLaravel\Models\Broadcasts;
 use Tonysm\TurboLaravel\Tests\TestCase;
 use Tonysm\TurboLaravel\Tests\TestModel;
 
-use function Tonysm\TurboLaravel\turbo_channel;
-
 class BroadcastsModelTest extends TestCase
 {
     protected function setUp(): void
@@ -33,7 +31,7 @@ class BroadcastsModelTest extends TestCase
 
         Bus::assertDispatched(function (BroadcastAction $job) use ($model) {
             $this->assertCount(1, $job->channels);
-            $this->assertEquals(sprintf('private-%s', turbo_channel($model)), $job->channels[0]->name);
+            $this->assertEquals(sprintf('private-%s', $model->broadcastChannel()), $job->channels[0]->name);
             $this->assertEquals('broadcast_test_models', $job->target);
             $this->assertEquals('append', $job->action);
             $this->assertEquals('broadcast_test_models._broadcast_test_model', $job->partial);
@@ -82,7 +80,7 @@ class BroadcastsModelTest extends TestCase
 
         Bus::assertDispatched(function (BroadcastAction $job) use ($model) {
             $this->assertCount(1, $job->channels);
-            $this->assertEquals(sprintf('private-%s', turbo_channel($model)), $job->channels[0]->name);
+            $this->assertEquals(sprintf('private-%s', $model->broadcastChannel()), $job->channels[0]->name);
             $this->assertEquals("broadcast_test_model_{$model->id}", $job->target);
             $this->assertEquals('replace', $job->action);
             $this->assertEquals('broadcast_test_models._broadcast_test_model', $job->partial);
@@ -105,7 +103,7 @@ class BroadcastsModelTest extends TestCase
 
         Bus::assertDispatched(function (BroadcastAction $job) use ($model) {
             $this->assertCount(1, $job->channels);
-            $this->assertEquals(sprintf('private-%s', turbo_channel($model)), $job->channels[0]->name);
+            $this->assertEquals(sprintf('private-%s', $model->broadcastChannel()), $job->channels[0]->name);
             $this->assertEquals("broadcast_test_model_{$model->id}", $job->target);
             $this->assertEquals('remove', $job->action);
             $this->assertNull($job->partial);
@@ -128,7 +126,7 @@ class BroadcastsModelTest extends TestCase
 
         Bus::assertDispatched(function (BroadcastAction $job) use ($model) {
             $this->assertCount(1, $job->channels);
-            $this->assertEquals(sprintf('private-%s', turbo_channel($model)), $job->channels[0]->name);
+            $this->assertEquals(sprintf('private-%s', $model->broadcastChannel()), $job->channels[0]->name);
             $this->assertEquals("broadcast_test_model_{$model->id}", $job->target);
             $this->assertEquals('replace', $job->action);
             $this->assertEquals('broadcast_test_models._broadcast_test_model', $job->partial);
@@ -147,7 +145,7 @@ class BroadcastsModelTest extends TestCase
 
         Bus::assertDispatched(function (BroadcastAction $job) use ($model) {
             $this->assertCount(1, $job->channels);
-            $this->assertEquals(sprintf('private-%s', turbo_channel($model)), $job->channels[0]->name);
+            $this->assertEquals(sprintf('private-%s', $model->broadcastChannel()), $job->channels[0]->name);
             $this->assertEquals('auto_broadcast_test_models', $job->target);
             $this->assertEquals('append', $job->action);
             $this->assertEquals('auto_broadcast_test_models._auto_broadcast_test_model', $job->partial);
@@ -166,7 +164,7 @@ class BroadcastsModelTest extends TestCase
 
         Bus::assertDispatched(function (BroadcastAction $job) use ($modelWithCustomInsert) {
             $this->assertCount(1, $job->channels);
-            $this->assertEquals(sprintf('private-%s', turbo_channel($modelWithCustomInsert)), $job->channels[0]->name);
+            $this->assertEquals(sprintf('private-%s', $modelWithCustomInsert->broadcastChannel()), $job->channels[0]->name);
             $this->assertEquals('auto_broadcast_with_custom_inserts_test_models', $job->target);
             $this->assertEquals('prepend', $job->action);
             $this->assertEquals('auto_broadcast_with_custom_inserts_test_models._auto_broadcast_with_custom_inserts_test_model', $job->partial);
@@ -186,7 +184,7 @@ class BroadcastsModelTest extends TestCase
 
         Bus::assertDispatched(function (BroadcastAction $job) use ($parent, $child) {
             $this->assertCount(1, $job->channels);
-            $this->assertEquals(sprintf('private-%s', turbo_channel($parent)), $job->channels[0]->name);
+            $this->assertEquals(sprintf('private-%s', $parent->broadcastChannel()), $job->channels[0]->name);
             $this->assertEquals('related_model_children', $job->target);
             $this->assertEquals('append', $job->action);
             $this->assertEquals('related_model_children._related_model_child', $job->partial);
@@ -206,7 +204,7 @@ class BroadcastsModelTest extends TestCase
 
         Bus::assertDispatched(function (BroadcastAction $job) use ($parent, $child) {
             $this->assertCount(1, $job->channels);
-            $this->assertEquals(sprintf('private-%s', turbo_channel($parent)), $job->channels[0]->name);
+            $this->assertEquals(sprintf('private-%s', $parent->broadcastChannel()), $job->channels[0]->name);
             $this->assertEquals('related_model_child_methods', $job->target);
             $this->assertEquals('append', $job->action);
             $this->assertEquals('related_model_child_methods._related_model_child_method', $job->partial);
@@ -245,7 +243,7 @@ class BroadcastsModelTest extends TestCase
 
         Bus::assertDispatched(function (BroadcastAction $job) use ($parent, $child) {
             $this->assertCount(1, $job->channels);
-            $this->assertSame(sprintf('private-%s', turbo_channel($parent)), $job->channels[0]->name);
+            $this->assertSame(sprintf('private-%s', $parent->broadcastChannel()), $job->channels[0]->name);
             $this->assertEquals('combined_properties_test_models', $job->target);
             $this->assertEquals('prepend', $job->action);
             $this->assertEquals('combined_properties_test_models._combined_properties_test_model', $job->partial);

--- a/tests/Views/RecordIdentifierTest.php
+++ b/tests/Views/RecordIdentifierTest.php
@@ -10,7 +10,6 @@ class RecordIdentifierTest extends TestCase
 {
     private $model;
     private $singular;
-    private $plural;
 
     protected function setUp(): void
     {
@@ -66,14 +65,16 @@ class RecordIdentifierTest extends TestCase
     {
         $this->model->save();
 
+        // This is now built into Laravel. I'm letting the test here in case something changes upstream.
+
         $this->assertEquals(
             sprintf('Tonysm.TurboLaravel.Tests.TestModel.%s', $this->model->getKey()),
-            (new RecordIdentifier($this->model))->channelName()
+            $this->model->broadcastChannel()
         );
 
         $this->assertEquals(
             'Tonysm.TurboLaravel.Tests.TestModel.{testModel}',
-            RecordIdentifier::channelAuthKey(get_class($this->model), "{testModel}")
+            $this->model->broadcastChannelRoute()
         );
     }
 }


### PR DESCRIPTION
### Removed

- **BC**: removes the `turbo_channel` and `turbo_channel_auth` helper functions because, because now Laravel has the conventions built-in. Because of this, we are requiring Laravel `^8.46` now.

### Changed

- Use `dispatch_sync` instead of `dispatch_now` because the latter was deprecated