### PR TITLE
Alpine 3, Laravel ^8.47, and Turbo v7.0.0-beta.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,8 @@ php artisan turbo:install --jet
 
 Then, you can run install your NPM dependencies and compile your assets normally.
 
-These are thje dependencies needed for Jetstream with Livewire to work with Turbo.js:
+These are the dependencies needed so Jetstream with Livewire works with Turbo.js:
 
-* [Alpine Turbo Bridge](https://github.com/SimoTod/alpine-turbo-drive-adapter), needed so Alpine.js works nicely; and
 * [Livewire Turbo Plugin](https://github.com/livewire/turbolinks) needed so Livewire works nicely. This one will be added to your Jetstream layouts as script tags fetching from a CDN (both `app.blade.php` and `guest.blade.php`)
 
 You may also optionally install [Stimulus.js](https://stimulus.hotwire.dev/) passing `--stimulus` flag to the `turbo:install` Artisan command:
@@ -73,7 +72,13 @@ php artisan turbo:install --jet --stimulus
 
 The package ships with a middleware which applies some conventions on your redirects, specially around how failed validations are handled automatically by Laravel. Read more about this in the [Conventions](#conventions) section of the documentation.
 
-You may add the middleware to the "web" route group on your HTTP Kernel, like so:
+You may add the middleware to the "web" route group on your HTTP Kernel:
+
+```php
+\Tonysm\TurboLaravel\Http\Middleware\TurboMiddleware::class,
+```
+
+Like so:
 
 ```php
 
@@ -122,7 +127,7 @@ First of all, none of these conventions are mandatory. Feel free to pick the one
 * You may want to use resource routes for most things (`posts.index`, `posts.store`, etc)
 * You may want to split your views into smaller chunks or _partials_ (small portions of HTML for specific fragments), such as `comments/_comment.blade.php` that displays a comment resource, or `comments/_form.blade.php` for the form to either create/update comments. This will allow you to reuse these partials in [Turbo Streams](#turbo-streams)
 * Your model's partial (such as the `comments/_comment.blade.php` for a `Comment` model, for example) may only rely on having a `$comment` instance passed to it. When broadcasting your model changes and generating the Turbo Streams in background, the package will pass the model instance using the model's basename in _camelCase_ to that partial - although you can fully control this behavior
-* You may use the model's Fully Qualified Class Name, or FQCN for short, on your Broadcasting Channel authorizations with a wildcard such as `.{id}`, such as `App.Models.Comment.{comment}` for a `Comment` model living in `App\\Models\\` - the wildcard's name doesn't matter. This is now the default broadcasting channel in Laravel (see [here](https://laravel.com/docs/8.x/broadcasting#model-broadcasting-conventions)).
+* You may use the model's Fully Qualified Class Name, or FQCN for short, on your Broadcasting Channel authorization routes with a wildcard, such as `App.Models.Comment.{comment}` for a `Comment` model living in `App\\Models\\` - the wildcard's name doesn't matter. This is now the default broadcasting channel in Laravel (see [here](https://laravel.com/docs/8.x/broadcasting#model-broadcasting-conventions)).
 
 In the [Overview section](#overview) below you will see how to override most of the default behaviors, if you want to.
 
@@ -258,9 +263,10 @@ return response()->turboStream()
     ->view('comments._comment', ['comment' => $comment]);
 ```
 
-There are 5 _actions_ in Turbo Streams. They are:
+There are 7 _actions_ in Turbo Streams. They are:
 
-* `append` & `prepend`: to add the elements in the target element after the existing contents or before, respectively
+* `append` & `prepend`: to add the elements in the target element at the top or at the bottom of its contents, respectively
+* `before` & `after`: to add the elements next to the target element before or after, respectively
 * `replace`: will replace the existing element entirely with the contents of the `template` tag in the Turbo Stream
 * `update`: will keep the target and only replace the contents of it with the contents of the `template` tag in the Turbo Stream
 * `remove`: will remove the element. This one doesn't need a `<template>` tag. It accepts either an instance of a Model or the DOM ID of the element to be removed as a string.
@@ -270,6 +276,8 @@ Which means you will find shorthand methods for them all, like:
 ```php
 response()->turboStream()->append($comment);
 response()->turboStream()->prepend($comment);
+response()->turboStream()->before($comment, 'target_dom_id');
+response()->turboStream()->after($comment, 'target_dom_id');
 response()->turboStream()->replace($comment);
 response()->turboStream()->update($comment);
 response()->turboStream()->remove($comment);
@@ -397,6 +405,8 @@ Here are the methods now available to your model:
 ```php
 $comment->broadcastAppend();
 $comment->broadcastPrepend();
+$comment->broadcastBefore('target_dom_id');
+$comment->broadcastAfter('target_dom_id');
 $comment->broadcastReplace();
 $comment->broadcastUpdate();
 $comment->broadcastRemove();
@@ -407,6 +417,8 @@ These methods will assume you want to broadcast the Turbo Streams to your model'
 ```php
 $comment->broadcastAppendTo($post);
 $comment->broadcastPrependTo($post);
+$comment->broadcastBeforeTo($post, 'target_dom_id');
+$comment->broadcastAfterTo($post, 'target_dom_id');
 $comment->broadcastReplaceTo($post);
 $comment->broadcastUpdateTo($post);
 $comment->broadcastRemoveTo($post);

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "illuminate/support": "^8.45"
+        "illuminate/support": "^8.47"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0",

--- a/src/Commands/TurboInstallCommand.php
+++ b/src/Commands/TurboInstallCommand.php
@@ -15,7 +15,7 @@ class TurboInstallCommand extends Command
     {
         $this->updateNodePackages(function ($packages) {
             return [
-                '@hotwired/turbo' => '^7.0.0-beta.5',
+                '@hotwired/turbo' => '^7.0.0-beta.7',
                 'laravel-echo' => '^1.10.0',
                 'pusher-js' => '^7.0.2',
             ] + $packages;

--- a/src/Commands/TurboInstallCommand.php
+++ b/src/Commands/TurboInstallCommand.php
@@ -33,8 +33,7 @@ class TurboInstallCommand extends Command
         if ($this->option('jet')) {
             $this->updateNodePackages(function ($packages) {
                 return [
-                    'alpinejs' => '^2.8.0',
-                    'alpine-turbo-drive-adapter' => '^1.0.1',
+                    'alpinejs' => '^3.0.6',
                 ] + $packages;
             });
 

--- a/src/Http/PendingTurboStreamResponse.php
+++ b/src/Http/PendingTurboStreamResponse.php
@@ -44,6 +44,16 @@ class PendingTurboStreamResponse implements Responsable
         return $this->inserted($model, 'prepend');
     }
 
+    public function before(Model $model, string $target): self
+    {
+        return $this->inserted($model, 'before', $target);
+    }
+
+    public function after(Model $model, string $target): self
+    {
+        return $this->inserted($model, 'after', $target);
+    }
+
     public function update(Model $model): self
     {
         return $this->updated($model, 'update');
@@ -117,9 +127,9 @@ class PendingTurboStreamResponse implements Responsable
         );
     }
 
-    private function inserted(Model $model, string $action): self
+    private function inserted(Model $model, string $action, ?string $target = null): self
     {
-        $this->useTarget = $this->getResourceNameFor($model);
+        $this->useTarget = $target ?: $this->getResourceNameFor($model);
         $this->useAction = $action;
         $this->partialView = $this->getPartialViewFor($model);
         $this->partialData = $this->getPartialDataFor($model);

--- a/src/Models/Broadcasts.php
+++ b/src/Models/Broadcasts.php
@@ -24,14 +24,30 @@ trait Broadcasts
     public function broadcastAppend(): PendingBroadcast
     {
         return $this->broadcastAppendTo(
-            $this->broadcastDetaultTargets()
+            $this->brodcastDefaultStreamables()
         );
     }
 
     public function broadcastPrepend(): PendingBroadcast
     {
         return $this->broadcastPrependTo(
-            $this->broadcastDetaultTargets()
+            $this->brodcastDefaultStreamables()
+        );
+    }
+
+    public function broadcastBefore(string $target): PendingBroadcast
+    {
+        return $this->broadcastBeforeTo(
+            $this->brodcastDefaultStreamables(),
+            $target
+        );
+    }
+
+    public function broadcastAfter(string $target): PendingBroadcast
+    {
+        return $this->broadcastAfterTo(
+            $this->brodcastDefaultStreamables(),
+            $target
         );
     }
 
@@ -42,7 +58,7 @@ trait Broadcasts
             : 'append';
 
         return $this->broadcastActionTo(
-            $this->broadcastDetaultTargets(),
+            $this->brodcastDefaultStreamables(),
             $action,
             Rendering::forModel($this),
         );
@@ -51,21 +67,21 @@ trait Broadcasts
     public function broadcastReplace(): PendingBroadcast
     {
         return $this->broadcastReplaceTo(
-            $this->broadcastDetaultTargets()
+            $this->brodcastDefaultStreamables()
         );
     }
 
     public function broadcastUpdate(): PendingBroadcast
     {
         return $this->broadcastUpdateTo(
-            $this->broadcastDetaultTargets()
+            $this->brodcastDefaultStreamables()
         );
     }
 
     public function broadcastRemove(): PendingBroadcast
     {
         return $this->broadcastRemoveTo(
-            $this->broadcastDetaultTargets()
+            $this->brodcastDefaultStreamables()
         );
     }
 
@@ -77,6 +93,16 @@ trait Broadcasts
     public function broadcastPrependTo($streamable): PendingBroadcast
     {
         return $this->broadcastActionTo($streamable, 'prepend', Rendering::forModel($this));
+    }
+
+    public function broadcastBeforeTo($streamable, string $target): PendingBroadcast
+    {
+        return $this->broadcastActionTo($streamable, 'before', Rendering::forModel($this), $target);
+    }
+
+    public function broadcastAfterTo($streamable, string $target): PendingBroadcast
+    {
+        return $this->broadcastActionTo($streamable, 'after', Rendering::forModel($this), $target);
     }
 
     public function broadcastReplaceTo($streamable): PendingBroadcast
@@ -94,17 +120,17 @@ trait Broadcasts
         return $this->broadcastActionTo($streamable, 'remove', Rendering::empty());
     }
 
-    protected function broadcastActionTo($streamables, string $action, Rendering $rendering): PendingBroadcast
+    protected function broadcastActionTo($streamables, string $action, Rendering $rendering, ?string $target = null): PendingBroadcast
     {
         return new PendingBroadcast(
             $this->toChannels(Collection::wrap($streamables)),
             $action,
-            $this->broadcastDefaultTarget($action),
+            $target ?: $this->broadcastDefaultTarget($action),
             $rendering,
         );
     }
 
-    protected function broadcastDetaultTargets()
+    protected function brodcastDefaultStreamables()
     {
         if (property_exists($this, 'broadcastsTo')) {
             return Collection::wrap($this->broadcastsTo)

--- a/src/TurboServiceProvider.php
+++ b/src/TurboServiceProvider.php
@@ -44,7 +44,7 @@ class TurboServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__ . '/../config/turbo-laravel.php', 'turbo-laravel');
 
-        $this->app->singleton(Turbo::class);
+        $this->app->scoped(Turbo::class);
         $this->app->bind(Broadcaster::class, LaravelBroadcaster::class);
     }
 

--- a/stubs/resources/js/alpine.js
+++ b/stubs/resources/js/alpine.js
@@ -1,2 +1,22 @@
-import 'alpine-turbo-drive-adapter';
-import 'alpinejs';
+import Alpine from 'alpinejs';
+window.Alpine = Alpine;
+
+Alpine.start();
+
+document.addEventListener('turbo:before-render', () => {
+    let permanents = document.querySelectorAll('[data-turbo-permanent]')
+
+    let undos = Array.from(permanents).map(el => {
+        el._x_ignore = true
+
+        return () => {
+            delete el._x_ignore
+        }
+    })
+
+    document.addEventListener('turbo:render', function handler() {
+        while(undos.length) undos.shift()()
+
+        document.removeEventListener('turbo:render', handler)
+    })
+})

--- a/tests/Http/ResponseMacrosTest.php
+++ b/tests/Http/ResponseMacrosTest.php
@@ -350,6 +350,44 @@ class ResponseMacrosTest extends TestCase
     }
 
     /** @test */
+    public function before_shorthand()
+    {
+        $response = response()
+            ->turboStream()
+            ->before($testModel = TestModel::create(['name' => 'Test model']), 'example_dom_id')
+            ->toResponse(new Request);
+
+        $expected = view('turbo-laravel::turbo-stream', [
+            'action' => 'before',
+            'target' => 'example_dom_id',
+            'partial' => 'test_models._test_model',
+            'partialData' => ['testModel' => $testModel],
+        ])->render();
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
+    public function after_shorthand()
+    {
+        $response = response()
+            ->turboStream()
+            ->after($testModel = TestModel::create(['name' => 'Test model']), 'example_dom_id')
+            ->toResponse(new Request);
+
+        $expected = view('turbo-laravel::turbo-stream', [
+            'action' => 'after',
+            'target' => 'example_dom_id',
+            'partial' => 'test_models._test_model',
+            'partialData' => ['testModel' => $testModel],
+        ])->render();
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
     public function response_builder_fails_when_partial_is_missing_and_not_a_remove_action()
     {
         $this->expectException(TurboStreamResponseFailedException::class);

--- a/tests/Models/BroadcastsModelTest.php
+++ b/tests/Models/BroadcastsModelTest.php
@@ -2,8 +2,8 @@
 
 namespace Tonysm\TurboLaravel\Tests\Models;
 
-use Bus;
 use Illuminate\Broadcasting\Channel;
+use Illuminate\Support\Facades\Bus;
 use Tonysm\TurboLaravel\Jobs\BroadcastAction;
 use Tonysm\TurboLaravel\Models\Broadcasts;
 use Tonysm\TurboLaravel\Tests\TestCase;
@@ -60,6 +60,104 @@ class BroadcastsModelTest extends TestCase
             $this->assertSame($channel, $job->channels[0]);
             $this->assertEquals('some_other_target', $job->target);
             $this->assertEquals('append', $job->action);
+            $this->assertEquals('another_partial', $job->partial);
+            $this->assertEquals(['lorem' => 'ipsum'], $job->partialData);
+
+            return true;
+        });
+    }
+
+    /** @test */
+    public function manually_before_with_overrides()
+    {
+        Bus::fake([BroadcastAction::class]);
+
+        $model = BroadcastTestModel::create(['name' => 'Testing']);
+
+        Bus::assertNotDispatched(BroadcastAction::class);
+
+        $model->broadcastBefore('example_dom_id_target')
+            ->to($channel = new Channel('hello'))
+            ->partial('another_partial', ['lorem' => 'ipsum']);
+
+        Bus::assertDispatched(function (BroadcastAction $job) use ($channel) {
+            $this->assertCount(1, $job->channels);
+            $this->assertSame($channel, $job->channels[0]);
+            $this->assertEquals('example_dom_id_target', $job->target);
+            $this->assertEquals('before', $job->action);
+            $this->assertEquals('another_partial', $job->partial);
+            $this->assertEquals(['lorem' => 'ipsum'], $job->partialData);
+
+            return true;
+        });
+    }
+
+    /** @test */
+    public function manually_after_with_overrides()
+    {
+        Bus::fake([BroadcastAction::class]);
+
+        $model = BroadcastTestModel::create(['name' => 'Testing']);
+
+        Bus::assertNotDispatched(BroadcastAction::class);
+
+        $model->broadcastAfter('example_dom_id_target')
+            ->to($channel = new Channel('hello'))
+            ->partial('another_partial', ['lorem' => 'ipsum']);
+
+        Bus::assertDispatched(function (BroadcastAction $job) use ($channel) {
+            $this->assertCount(1, $job->channels);
+            $this->assertSame($channel, $job->channels[0]);
+            $this->assertEquals('example_dom_id_target', $job->target);
+            $this->assertEquals('after', $job->action);
+            $this->assertEquals('another_partial', $job->partial);
+            $this->assertEquals(['lorem' => 'ipsum'], $job->partialData);
+
+            return true;
+        });
+    }
+
+    /** @test */
+    public function manually_before_to_with_overrides()
+    {
+        Bus::fake([BroadcastAction::class]);
+
+        $model = BroadcastTestModel::create(['name' => 'Testing']);
+
+        Bus::assertNotDispatched(BroadcastAction::class);
+
+        $model->broadcastBeforeTo($channel = new Channel('hello'), 'example_dom_id_target')
+            ->partial('another_partial', ['lorem' => 'ipsum']);
+
+        Bus::assertDispatched(function (BroadcastAction $job) use ($channel) {
+            $this->assertCount(1, $job->channels);
+            $this->assertSame($channel, $job->channels[0]);
+            $this->assertEquals('example_dom_id_target', $job->target);
+            $this->assertEquals('before', $job->action);
+            $this->assertEquals('another_partial', $job->partial);
+            $this->assertEquals(['lorem' => 'ipsum'], $job->partialData);
+
+            return true;
+        });
+    }
+
+    /** @test */
+    public function manually_after_to_with_overrides()
+    {
+        Bus::fake([BroadcastAction::class]);
+
+        $model = BroadcastTestModel::create(['name' => 'Testing']);
+
+        Bus::assertNotDispatched(BroadcastAction::class);
+
+        $model->broadcastAfterTo($channel = new Channel('hello'), 'example_dom_id_target')
+            ->partial('another_partial', ['lorem' => 'ipsum']);
+
+        Bus::assertDispatched(function (BroadcastAction $job) use ($channel) {
+            $this->assertCount(1, $job->channels);
+            $this->assertSame($channel, $job->channels[0]);
+            $this->assertEquals('example_dom_id_target', $job->target);
+            $this->assertEquals('after', $job->action);
             $this->assertEquals('another_partial', $job->partial);
             $this->assertEquals(['lorem' => 'ipsum'], $job->partialData);
 


### PR DESCRIPTION
### Added

- Adds the `broadcastAfter` and `broadcastBefore` methods as well as the `broadcastAfterTo` and `broadcastBeforeTo` to the `Broadcasts` trait
- Adds the `before()` and `after()`  methods to the Turbo Stream response builder, so you can do things like `response()->turboStream()->before($model, 'dom_id')`

### Changed

- Change the installation to make sure Alpine 3 is installed, and add the snippet that Caleb shared
- Change the installation to make sure Turbo ^7.0.0-beta.7 is installed
- Require Laravel `^8.47` so I can use the scoped instances for the turbo helper, instead of Singleton
- Updated the documentation to mention the new broadcast methods and remove reference to the alpine bridge

---

closes #24 #23