### PR TITLE
Add ability for other resources to be turbo-streamable

### DIFF
--- a/src/Models/Naming/Name.php
+++ b/src/Models/Naming/Name.php
@@ -2,7 +2,6 @@
 
 namespace Tonysm\TurboLaravel\Models\Naming;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
 class Name
@@ -51,7 +50,7 @@ class Name
      */
     public string $element;
 
-    public static function forModel(Model $model)
+    public static function forModel(object $model)
     {
         return static::build(get_class($model));
     }

--- a/src/Views/TurboStreamable.php
+++ b/src/Views/TurboStreamable.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tonysm\TurboLaravel\Views;
+
+interface TurboStreamable
+{
+    public function getDomId();
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -2,18 +2,17 @@
 
 namespace Tonysm\TurboLaravel;
 
-use Illuminate\Database\Eloquent\Model;
 use Tonysm\TurboLaravel\Views\RecordIdentifier;
 
 /**
  * Generates the DOM ID for a specific model.
  *
- * @param Model $model
+ * @param object $model
  * @param string $prefix
  *
  * @return string
  */
-function dom_id(Model $model, string $prefix = ""): string
+function dom_id(object $model, string $prefix = ""): string
 {
     return (new RecordIdentifier($model))->domId($prefix);
 }
@@ -21,11 +20,11 @@ function dom_id(Model $model, string $prefix = ""): string
 /**
  * Generates the DOM CSS Class for a specific model.
  *
- * @param Model $model
+ * @param object $model
  * @param string $prefix
  * @return string
  */
-function dom_class(Model $model, string $prefix = ""): string
+function dom_class(object $model, string $prefix = ""): string
 {
     return (new RecordIdentifier($model))->domClass($prefix);
 }

--- a/tests/Stubs/Models/TestTurboStreamable.php
+++ b/tests/Stubs/Models/TestTurboStreamable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tonysm\TurboLaravel\Tests\Stubs\Models;
+
+use Tonysm\TurboLaravel\Views\TurboStreamable;
+
+class TestTurboStreamable implements TurboStreamable
+{
+    public function getDomId()
+    {
+        return 'turbo-dom-id';
+    }
+}

--- a/tests/TestTurboStreamable.php
+++ b/tests/TestTurboStreamable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tonysm\TurboLaravel\Tests;
+
+use Tonysm\TurboLaravel\Views\TurboStreamable;
+
+class TestTurboStreamable implements TurboStreamable
+{
+    public function getDomId()
+    {
+        return 'turbo-dom-id';
+    }
+}

--- a/tests/Views/RecordIdentifierStreamableTest.php
+++ b/tests/Views/RecordIdentifierStreamableTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tonysm\TurboLaravel\Tests\Views;
+
+use RuntimeException;
+use stdClass;
+use Tonysm\TurboLaravel\Tests\TestCase;
+use Tonysm\TurboLaravel\Tests\TestTurboStreamable;
+use Tonysm\TurboLaravel\Views\RecordIdentifier;
+
+class RecordIdentifierStreamableTest extends TestCase
+{
+    private $streamable;
+    private $singular;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->streamable = new TestTurboStreamable;
+        $this->singular = "test_turbo_streamable";
+    }
+
+    /** @test */
+    public function dom_id_of_streamable()
+    {
+        $this->assertEquals("{$this->singular}_turbo-dom-id", (new RecordIdentifier($this->streamable))->domId());
+    }
+
+    /** @test */
+    public function dom_id_of_streamable_with_custom_prefix()
+    {
+        $this->assertEquals("custom_prefix_{$this->singular}_turbo-dom-id", (new RecordIdentifier($this->streamable))->domId("custom_prefix"));
+    }
+    
+    /** @test */
+    public function exception_is_thrown_when_given_non_streamable_instance()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('[stdClass] must be an instance of Eloquent or TurboStreamable.');
+
+        new RecordIdentifier(new stdClass);
+    }
+}

--- a/tests/Views/RecordIdentifierTest.php
+++ b/tests/Views/RecordIdentifierTest.php
@@ -17,7 +17,6 @@ class RecordIdentifierTest extends TestCase
 
         $this->model = new TestModel(['name' => 'Hello']);
         $this->singular = "test_model";
-        $this->plural = "test_models";
     }
 
     /** @test */

--- a/tests/Views/ViewHelpersTest.php
+++ b/tests/Views/ViewHelpersTest.php
@@ -52,6 +52,18 @@ class ViewHelpersTest extends TestCase
     }
 
     /** @test */
+    public function renders_streamable_dom_id()
+    {
+        $testStreamable = new Models\TestTurboStreamable;
+
+        $renderedDomId = View::file(__DIR__ . '/../Stubs/views/domid.blade.php', ['model' => $testStreamable])->render();
+        $renderedDomIdWithPrefix = View::file(__DIR__ . '/../Stubs/views/domid_with_prefix.blade.php', ['model' => $testStreamable])->render();
+
+        $this->assertEquals('<div id="test_turbo_streamable_turbo-dom-id"></div>', trim($renderedDomId));
+        $this->assertEquals('<div id="favorites_test_turbo_streamable_turbo-dom-id"></div>', trim($renderedDomIdWithPrefix));
+    }
+
+    /** @test */
     public function renders_dom_class()
     {
         $testModel = Models\TestModel::create(['name' => 'lorem']);
@@ -63,6 +75,18 @@ class ViewHelpersTest extends TestCase
         $this->assertEquals('<div class="test_model"></div>', trim($renderedDomClass));
         $this->assertEquals('<div class="favorites_test_model"></div>', trim($renderedDomClassWithPrefix));
         $this->assertEquals('<div class="test_model"></div>', trim($rendersDomClassOfNewModel));
+    }
+
+    /** @test */
+    public function renders_streamable_dom_class()
+    {
+        $testModel = new Models\TestTurboStreamable;
+
+        $renderedDomClass = View::file(__DIR__ . '/../Stubs/views/domclass.blade.php', ['model' => $testModel])->render();
+        $renderedDomClassWithPrefix = View::file(__DIR__ . '/../Stubs/views/domclass_with_prefix.blade.php', ['model' => $testModel])->render();
+
+        $this->assertEquals('<div class="test_turbo_streamable"></div>', trim($renderedDomClass));
+        $this->assertEquals('<div class="favorites_test_turbo_streamable"></div>', trim($renderedDomClassWithPrefix));
     }
 
     /** @test */


### PR DESCRIPTION
### Purpose

This PR adds the ability for any PHP object to be turbo-streamable by implementing the `TurboStreamable` interface.

### Description

I'm the developer of a PHP package called [LdapRecord](https://github.com/DirectoryTree/LdapRecord) that heavily integrates into Laravel and want to be able to use turbo-laravel with LdapRecord models. This isn't possible currently, since Eloquent models are type-hinted into this package.

This PR opens the door for any PHP object to be "turbo-streamable" by implementing a `getDomId()` method.

In my case, this is how I would utilize this with LdapRecord models:

```php
use LdapRecord\Models\Model;
use Tonysm\TurboLaravel\Views\TurboStreamable;

class User extends Model implements TurboStreamble
{
    public function getDomId()
    {
        return $this->getObjectGuid();
    }
}
```

### Notes

The namespace and location of `TurboStreamable` might need to be changed -- I wasn't sure where you might want this placed or named.

Let me know if you have any comments/concerns/questions. Thanks for your hard work on this package!