### PR TITLE
Better Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,52 +710,107 @@ if (Turbo::isTurboNativeVisit()) {
 <a name="testing-helpers"></a>
 ### Testing Helpers
 
-There is a [companion package](https://github.com/tonysm/turbo-laravel-test-helpers) that you may use as a dev dependency on your application to help with testing your apps using Turbo Laravel. First, install the package:
+There are two aspects of your application using Turbo Laravel that are specific this approach itself:
 
-```bash
-composer require tonysm/turbo-laravel-test-helpers --dev
-```
+1. **Turbo Stream HTTP responses.** As you return Turbo Stream responses from your route handlers/controllers to be applied by Turbo itself; and
+1. **Turbo Stream broadcasts.** Which is the side-effect of certain model changes or whenever you call `$model->broadcastAppend()` on your models, for instance.
 
-And then you will be able to test your application like:
+We're going to cover both of these scenarios here.
 
-``` php
-use Tonysm\TurboLaravelTestHelpers\Testing\InteractsWithTurbo;
+#### Making Turbo & Turbo Native HTTP requests
 
-class ExampleTest extends TestCase
+To enhance your testing capabilities here, Turbo Laravel adds a couple of macros to the TestResponse that Laravel uses under the hood. The goal is that testing Turbo Stream responses is as convenient as testing regular HTTP responses.
+
+To mimic Turbo requests, which means sending a request setting the correct Content-Type in the `Accept:` HTTP header, you need to use the `InteractsWithTurbo` trait to your testcase. Now you can mimic a Turbo HTTP request by using the `$this->turbo()` method before you make the HTTP call itself. You can also mimic Turbo Native specific requests by using the `$this->turboNative()` also before you make the HTTP call. The first method will add the correct Turbo Stream content type to the `Accept:` header, and the second method will add Turbo Native `User-Agent:` value.
+
+These methods are handy when you are conditionally returning Turbo Stream responses based on the `request()->wantsTurboStream()` helper, for instance. Or when using the `@turbonative` or `@unlessturbonative` Blade directives.
+
+### Testing Turbo Stream HTTP Responses
+
+You can test if you got a Turbo Stream response by using the `assertTurboStream`. Similarly, you can assert that your response is _not_ a Turbo Stream response by using the `assertNotTurboStream()` macro:
+
+```php
+use Tonysm\TurboLaravel\Testing\InteractsWithTurbo;
+
+class CreateTodosTest extends TestCase
 {
     use InteractsWithTurbo;
 
     /** @test */
-    public function turbo_stream_test()
+    public function creating_todo_from_turbo_request_returns_turbo_stream_response()
     {
-        $response = $this->turbo()->post('my-route');
+        $response = $this->turbo()->post(route('todos.store'), [
+            'content' => 'Test the app',
+        ]);
 
         $response->assertTurboStream();
-
-        $response->assertHasTurboStream($target = 'users', $action = 'append');
-
-        $response->assertDoesntHaveTurboStream($target = 'empty_users', $action = 'remove');
     }
 
     /** @test */
-    public function turbo_native_shows()
+    public function creating_todo_from_regular_request_does_not_return_turbo_stream_response()
     {
-        $response = $this->turboNative()->get('my-route');
+        // Notice we're not chaining the `$this->turbo()` method here.
+        $response = $this->post(route('todos.store'), [
+            'content' => 'Test the app',
+        ]);
 
-        $response->assertSee('Only rendered in Turbo Native');
+        $response->assertNotTurboStream();
     }
 }
 ```
 
-Check out the [package repository](https://github.com/tonysm/turbo-laravel-test-helpers) if you want to know more about it.
-
-All model's broadcast will dispatch a `Tonysm\TurboLaravel\Jobs\BroadcastAction` job (either to a worker or process them immediately). You may also use that to test your broadcasts like so:
+The controller for such response would be something like this:
 
 ```php
-use App\Models\Post;
-use Tonysm\TurboLaravel\Jobs\BroadcastAction;
+class TodosController
+{
+    public function store()
+    {
+        $todo = auth()->user()->todos()->create(request()->validate([
+            'content' => ['required'],
+        ]));
 
-use function Tonysm\TurboLaravel\turbo_channel;
+        if (request()->wantsTurboStream()) {
+            return response()->turboStream($todo);
+        }
+
+        return redirect()->route('todos.index');
+    }
+}
+```
+
+#### Fluent Turbo Stream Testing
+
+You can get specific on your Turbo Stream responses by passing a callback to the `assertTurboStream(fn)` method. This can be used to test that you have a specific Turbo Stream tag being returned, or that you're returning exactly 3 Turbo Stream tags, for instance:
+
+```php
+/** @test */
+public function create_todos()
+{
+    $this->get(route('todos.store'))
+        ->assertTurboStream(fn (AssertableTurboStream $turboStreams) => (
+            $turboStreams->has(2)
+            && $turboStreams->hasTurboStream(fn ($turboStream) => (
+                $turboStream->where('target', 'flash_messages')
+                            ->where('action', 'prepend')
+                            ->see('Todo was successfully created!')
+            ))
+            && $turboStreams->hasTurboStream(fn ($turboStream) => (
+                $turboStream->where('target', 'todos')
+                            ->where('action', 'append')
+                            ->see('Test the app')
+            ))
+        ));
+}
+```
+
+#### Testing Turbo Stream Broadcasts
+
+Every broadcast will be dispatched using the `Tonysm\TurboLaravel\Jobs\BroadcastAction` job (either to a worker or to process immediately). You may also use that to test your broadcasts like so:
+
+```php
+use App\Models\Todo;
+use Tonysm\TurboLaravel\Jobs\BroadcastAction;
 
 class CreatesCommentsTest extends TestCase
 {
@@ -764,20 +819,20 @@ class CreatesCommentsTest extends TestCase
     {
         Bus::fake(BroadcastAction::class);
 
-        $post = Post::factory()->create();
+        $todo = Todo::factory()->create();
 
-        $this->turbo()->post(route('posts.comments.store', $post), [
-            'content' => 'Hello, World',
+        $this->turbo()->post(route('todos.comments.store', $todo), [
+            'content' => 'Hey, this is really nice!',
         ])->assertTurboStream();
 
-        Bus::assertDispatched(function (BroadcastAction $job) use($post) {
+        Bus::assertDispatched(function (BroadcastAction $job) use ($todo) {
             return count($job->channels) === 1
-                && $job->channels[0]->name === sprintf('private-%s', $post->broadcastChannel())
+                && $job->channels[0]->name === sprintf('private-%s', $todo->broadcastChannel())
                 && $job->target === 'comments'
                 && $job->action === 'append'
                 && $job->partial === 'comments._comment'
                 && $job->partialData['comment']->is(
-                    $post->comments->first()
+                    $todo->comments->first()
                 );
         });
     }
@@ -795,7 +850,7 @@ Try the package out. Use your Browser's DevTools to inspect the responses. You w
 
 Make something awesome!
 
-## Testing
+## Testing the Package
 
 ```bash
 composer test

--- a/README.md
+++ b/README.md
@@ -806,7 +806,7 @@ public function create_todos()
 
 #### Testing Turbo Stream Broadcasts
 
-Every broadcast will be dispatched using the `Tonysm\TurboLaravel\Jobs\BroadcastAction` job (either to a worker or to process immediately). You may also use that to test your broadcasts like so:
+Every broadcast will be dispatched using the `Tonysm\TurboLaravel\Jobs\BroadcastAction` job (either to a worker or process synchronously). You may also use that to test your broadcasts like so:
 
 ```php
 use App\Models\Todo;

--- a/README.md
+++ b/README.md
@@ -781,7 +781,7 @@ class TodosController
 
 #### Fluent Turbo Stream Testing
 
-You can get specific on your Turbo Stream responses by passing a callback to the `assertTurboStream(fn)` method. This can be used to test that you have a specific Turbo Stream tag being returned, or that you're returning exactly 3 Turbo Stream tags, for instance:
+You can get specific on your Turbo Stream responses by passing a callback to the `assertTurboStream(fn)` method. This can be used to test that you have a specific Turbo Stream tag being returned, or that you're returning exactly 2 Turbo Stream tags, for instance:
 
 ```php
 /** @test */

--- a/src/Commands/TurboInstallCommand.php
+++ b/src/Commands/TurboInstallCommand.php
@@ -15,7 +15,7 @@ class TurboInstallCommand extends Command
     {
         $this->updateNodePackages(function ($packages) {
             return [
-                '@hotwired/turbo' => '^7.0.0-beta.7',
+                '@hotwired/turbo' => '^7.0.0-beta.8',
                 'laravel-echo' => '^1.10.0',
                 'pusher-js' => '^7.0.2',
             ] + $packages;

--- a/src/Testing/AssertableTurboStream.php
+++ b/src/Testing/AssertableTurboStream.php
@@ -54,10 +54,14 @@ class AssertableTurboStream
 
     private function parsed(): Collection
     {
-        $parsed = simplexml_load_string(<<<XML
-        <xml>{$this->response->content()}</xml>
-        XML);
+        if (! isset($this->parsedCollection)) {
+            $parsed = simplexml_load_string(<<<XML
+            <xml>{$this->response->content()}</xml>
+            XML);
 
-        return $this->parsedCollection ??= collect(json_decode(json_encode($parsed), true)['turbo-stream']);
+            $this->parsedCollection = collect(json_decode(json_encode($parsed), true)['turbo-stream']);
+        }
+
+        return $this->parsedCollection;
     }
 }

--- a/src/Testing/AssertableTurboStream.php
+++ b/src/Testing/AssertableTurboStream.php
@@ -2,7 +2,31 @@
 
 namespace Tonysm\TurboLaravel\Testing;
 
+use Illuminate\Support\Collection;
+use Illuminate\Testing\TestResponse;
+use PHPUnit\Framework\Assert;
+
 class AssertableTurboStream
 {
+    public TestResponse $response;
+    public Collection $parsedCollection;
 
+    public function __construct(TestResponse $response)
+    {
+        $this->response = $response;
+    }
+
+    public function has(int $expectedTurboStreamsCount): self
+    {
+        Assert::assertCount($expectedTurboStreamsCount, $this->parsed());
+
+        return $this;
+    }
+
+    public function parsed(): Collection
+    {
+        return $this->parsedCollection ??= collect(json_decode(json_encode(simplexml_load_string(<<<XML
+<xml>{$this->response->content()}</xml>
+XML)), true)['turbo-stream']);
+    }
 }

--- a/src/Testing/AssertableTurboStream.php
+++ b/src/Testing/AssertableTurboStream.php
@@ -4,23 +4,21 @@ namespace Tonysm\TurboLaravel\Testing;
 
 use Closure;
 use Illuminate\Support\Collection;
-use Illuminate\Testing\TestResponse;
 use PHPUnit\Framework\Assert;
 
 class AssertableTurboStream
 {
-    public TestResponse $response;
-    public Collection $parsedCollection;
+    /** @var Collection */
+    public $turboStreams;
 
-    public function __construct(TestResponse $response)
+    public function __construct(Collection $turboStreams)
     {
-        $this->response = $response;
-        $this->parsedCollection = (new ConvertTestResponseToTurboStreamCollection)($response);
+        $this->turboStreams = $turboStreams;
     }
 
     public function has(int $expectedTurboStreamsCount): self
     {
-        Assert::assertCount($expectedTurboStreamsCount, $this->parsedCollection);
+        Assert::assertCount($expectedTurboStreamsCount, $this->turboStreams);
 
         return $this;
     }
@@ -29,7 +27,7 @@ class AssertableTurboStream
     {
         $attrs = collect();
 
-        $matches = $this->parsedCollection
+        $matches = $this->turboStreams
             ->mapInto(TurboStreamMatcher::class)
             ->filter(function ($matcher) use ($callback, $attrs) {
                 if (! $matcher->matches($callback)) {

--- a/src/Testing/AssertableTurboStream.php
+++ b/src/Testing/AssertableTurboStream.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tonysm\TurboLaravel\Testing;
+
+class AssertableTurboStream
+{
+
+}

--- a/src/Testing/ConvertTestResponseToTurboStreamCollection.php
+++ b/src/Testing/ConvertTestResponseToTurboStreamCollection.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tonysm\TurboLaravel\Testing;
+
+use Illuminate\Support\Collection;
+use Illuminate\Testing\TestResponse;
+
+class ConvertTestResponseToTurboStreamCollection
+{
+    public function __invoke(TestResponse $response): Collection
+    {
+        $parsed = simplexml_load_string(<<<XML
+        <xml>{$response->content()}</xml>
+        XML);
+
+        return collect(json_decode(json_encode($parsed), true)['turbo-stream']);
+    }
+}

--- a/src/Testing/InteractsWithTurbo.php
+++ b/src/Testing/InteractsWithTurbo.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tonysm\TurboLaravel\Testing;
+
+use Tonysm\TurboLaravel\Turbo;
+
+/**
+ * @mixin \Illuminate\Foundation\Testing\Concerns\MakesHttpRequests
+ */
+trait InteractsWithTurbo
+{
+    public function turbo(): self
+    {
+        return $this->withHeader('Accept', Turbo::TURBO_STREAM_FORMAT);
+    }
+
+    public function turboNative(): self
+    {
+        return $this->withHeader('User-Agent', 'Turbo Native Android; Mozilla: Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.3 Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0) Gecko/20100101 Firefox/43.4');
+    }
+}

--- a/src/Testing/TurboStreamMatcher.php
+++ b/src/Testing/TurboStreamMatcher.php
@@ -21,6 +21,10 @@ class TurboStreamMatcher
 
     public function where(string $prop, string $value): self
     {
+        // We're storing the props locally because we need to
+        // wait for the `->matches()` call to check if this
+        // Turbo Stream has all the attributes at once.
+
         $this->wheres[$prop] = $value;
 
         return $this;
@@ -28,6 +32,10 @@ class TurboStreamMatcher
 
     public function see(string $content): self
     {
+        // Similarly to how we do with the attributes, the contents
+        // of the Turbo Stream tag the user wants to assert will
+        // be store for latter, after the `->matches()` call.
+
         $this->contents[] = $content;
 
         return $this;
@@ -35,9 +43,17 @@ class TurboStreamMatcher
 
     public function matches(Closure $callback = null): bool
     {
+        // We first pass the current instance to the callback given in the
+        // `->assertTurboStream(fn)` call. This is where the `->where()`
+        // and `->see()` methods will be called by the developers.
+
         if ($callback) {
             $callback($this);
         }
+
+        // After registering the desired attributes and contents the developers want
+        // to assert against the Turbo Stream, we can check if this Turbo Stream
+        // has the props first and then if the Turbo Stream's contents match.
 
         if (! $this->matchesProps()) {
             return false;
@@ -69,6 +85,10 @@ class TurboStreamMatcher
         if (empty($this->contents)) {
             return true;
         }
+
+        // To assert that the Turbo Stream contains the desired text, we first need to
+        // rebuild the markup from the response. This is because we had to parse the
+        // HTML before getting here so we could assert each Turbo Stream separately.
 
         $content = new TestResponse(new Response($this->makeElements($this->turboStream['template'] ?? [])));
 

--- a/src/Testing/TurboStreamMatcher.php
+++ b/src/Testing/TurboStreamMatcher.php
@@ -32,9 +32,11 @@ class TurboStreamMatcher
         return $this;
     }
 
-    public function matches(Closure $callback): bool
+    public function matches(Closure $callback = null): bool
     {
-        $callback($this);
+        if ($callback) {
+            $callback($this);
+        }
 
         if (! $this->matchesProps()) {
             return false;

--- a/src/Testing/TurboStreamMatcher.php
+++ b/src/Testing/TurboStreamMatcher.php
@@ -48,8 +48,7 @@ class TurboStreamMatcher
 
     public function attrs(): string
     {
-        return trim(collect($this->wheres)
-            ->reduce(fn ($acc, $val, $prop) => $acc . ' ' . sprintf('%s="%s"', $prop, $val), ''));
+        return $this->makeAttributes($this->wheres);
     }
 
     private function matchesProps()
@@ -80,6 +79,11 @@ class TurboStreamMatcher
         return true;
     }
 
+    private function makeAttributes(array $attributes): string
+    {
+        return (new ComponentAttributeBag($attributes))->toHtml();
+    }
+
     private function makeElements($tags)
     {
         if (is_string($tags)) {
@@ -89,10 +93,10 @@ class TurboStreamMatcher
         $content = '';
 
         foreach ($tags as $tag => $contents) {
-            $attrs = new ComponentAttributeBag($contents['@attributes'] ?? []);
+            $attrs = $this->makeAttributes($contents['@attributes'] ?? []);
 
             $strContent = $this->makeElements(is_array($contents) ? Arr::except($contents, '@attributes') : $contents);
-            $opening = trim(sprintf('%s %s', $tag, $attrs->toHtml()));
+            $opening = trim(sprintf('%s %s', $tag, $attrs));
 
             if ($this->isSelfClosingTag($tag)) {
                 $content .= "<{$opening} />";

--- a/src/Testing/TurboStreamMatcher.php
+++ b/src/Testing/TurboStreamMatcher.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tonysm\TurboLaravel\Testing;
+
+use Closure;
+use Illuminate\Http\Response;
+use Illuminate\Support\Arr;
+use Illuminate\Testing\TestResponse;
+
+class TurboStreamMatcher
+{
+    private array $wheres = [];
+    private array $contents = [];
+
+    public function __construct(public $turboStream)
+    {
+    }
+
+    public function where(string $prop, string $value): self
+    {
+        $this->wheres[$prop] = $value;
+
+        return $this;
+    }
+
+    public function see(string $content): self
+    {
+        $this->contents[] = $content;
+
+        return $this;
+    }
+
+    public function matches(Closure $callback): bool
+    {
+        $callback($this);
+
+        if (! $this->matchesProps()) {
+            return false;
+        }
+
+        return $this->matchesContents();
+    }
+
+    public function attrs(): string
+    {
+        return trim(collect($this->wheres)
+            ->reduce(fn ($acc, $val, $prop) => $acc . ' ' . sprintf('%s="%s"', $prop, $val), ''));
+    }
+
+    private function matchesProps()
+    {
+        foreach ($this->wheres as $prop => $value) {
+            $actualProp = $this->turboStream['@attributes'][$prop] ?? false;
+
+            if ($actualProp === false || $actualProp !== $value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function matchesContents()
+    {
+        if (empty($this->contents)) {
+            return true;
+        }
+
+        $content = new TestResponse(new Response($this->makeElements($this->turboStream['template'] ?? [])));
+
+        foreach ($this->contents as $expectedContent) {
+            $content->assertSee($expectedContent);
+        }
+
+        return true;
+    }
+
+    private function makeElements($tags)
+    {
+        if (is_string($tags)) {
+            return $tags;
+        }
+
+        $content = '';
+
+        foreach ($tags as $tag => $contents) {
+            $attrs = trim(collect($contents['@attributes'] ?? [])
+                ->reduce(fn ($acc, $val, $prop) => $acc . ' ' . sprintf('%s="%s"', $prop, $val), ''));
+
+            $strContent = $this->makeElements(is_array($contents) ? Arr::except($contents, '@attributes') : $contents);
+            $opening = trim(sprintf('%s %s', $tag, $attrs));
+
+            $content .= "<{$opening}>{$strContent}</{$tag}>";
+        }
+
+        return $content;
+    }
+}

--- a/src/Testing/TurboStreamMatcher.php
+++ b/src/Testing/TurboStreamMatcher.php
@@ -9,11 +9,13 @@ use Illuminate\Testing\TestResponse;
 
 class TurboStreamMatcher
 {
+    private $turboStream;
     private array $wheres = [];
     private array $contents = [];
 
-    public function __construct(public $turboStream)
+    public function __construct($turboStream)
     {
+        $this->turboStream = $turboStream;
     }
 
     public function where(string $prop, string $value): self

--- a/src/Testing/TurboStreamMatcher.php
+++ b/src/Testing/TurboStreamMatcher.php
@@ -95,7 +95,7 @@ class TurboStreamMatcher
             $opening = trim(sprintf('%s %s', $tag, $attrs->toHtml()));
 
             if ($this->isSelfClosingTag($tag)) {
-                $content .= $tag === 'br' ? "<{$opening}>": "<{$opening} />";
+                $content .= "<{$opening} />";
             } else {
                 $content .= "<{$opening}>{$strContent}</{$tag}>";
             }

--- a/src/TurboServiceProvider.php
+++ b/src/TurboServiceProvider.php
@@ -15,7 +15,7 @@ use Tonysm\TurboLaravel\Broadcasters\Broadcaster;
 use Tonysm\TurboLaravel\Broadcasters\LaravelBroadcaster;
 use Tonysm\TurboLaravel\Commands\TurboInstallCommand;
 use Tonysm\TurboLaravel\Facades\Turbo as TurboFacade;
-use Tonysm\TurboLaravel\Httpclass\PendingTurboStreamResponse;
+use Tonysm\TurboLaravel\Http\PendingTurboStreamResponse;
 use Tonysm\TurboLaravel\Http\TurboResponseFactory;
 use Tonysm\TurboLaravel\Testing\AssertableTurboStream;
 

--- a/src/TurboServiceProvider.php
+++ b/src/TurboServiceProvider.php
@@ -18,6 +18,7 @@ use Tonysm\TurboLaravel\Facades\Turbo as TurboFacade;
 use Tonysm\TurboLaravel\Http\PendingTurboStreamResponse;
 use Tonysm\TurboLaravel\Http\TurboResponseFactory;
 use Tonysm\TurboLaravel\Testing\AssertableTurboStream;
+use Tonysm\TurboLaravel\Testing\ConvertTestResponseToTurboStreamCollection;
 
 class TurboServiceProvider extends ServiceProvider
 {
@@ -114,7 +115,8 @@ class TurboServiceProvider extends ServiceProvider
                 return;
             }
 
-            $callback(new AssertableTurboStream($this));
+            $turboStreams = (new ConvertTestResponseToTurboStreamCollection)($this);
+            $callback(new AssertableTurboStream($turboStreams));
         });
 
         TestResponse::macro('assertNotTurboStream', function () {

--- a/src/TurboServiceProvider.php
+++ b/src/TurboServiceProvider.php
@@ -8,12 +8,14 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Response;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
+use Illuminate\Testing\TestResponse;
 use Illuminate\View\View;
+use PHPUnit\Framework\Assert;
 use Tonysm\TurboLaravel\Broadcasters\Broadcaster;
 use Tonysm\TurboLaravel\Broadcasters\LaravelBroadcaster;
 use Tonysm\TurboLaravel\Commands\TurboInstallCommand;
 use Tonysm\TurboLaravel\Facades\Turbo as TurboFacade;
-use Tonysm\TurboLaravel\Http\PendingTurboStreamResponse;
+use Tonysm\TurboLaravel\Httpclass\PendingTurboStreamResponse;
 use Tonysm\TurboLaravel\Http\TurboResponseFactory;
 
 class TurboServiceProvider extends ServiceProvider
@@ -38,6 +40,7 @@ class TurboServiceProvider extends ServiceProvider
 
         $this->bindBladeMacros();
         $this->bindRequestAndResponseMacros();
+        $this->bindTestResponseMacros();
     }
 
     public function register()
@@ -91,6 +94,27 @@ class TurboServiceProvider extends ServiceProvider
 
         Request::macro('wantsTurboStream', function () {
             return Str::contains($this->header('Accept'), Turbo::TURBO_STREAM_FORMAT);
+        });
+    }
+
+    protected function bindTestResponseMacros()
+    {
+        if (! app()->environment('testing')) {
+            return;
+        }
+
+        TestResponse::macro('assertTurboStream', function () {
+            Assert::assertStringContainsString(
+                Turbo::TURBO_STREAM_FORMAT,
+                $this->headers->get('Content-Type'),
+            );
+        });
+
+        TestResponse::macro('assertNotTurboStream', function () {
+            Assert::assertStringNotContainsString(
+                Turbo::TURBO_STREAM_FORMAT,
+                $this->headers->get('Content-Type'),
+            );
         });
     }
 }

--- a/src/TurboServiceProvider.php
+++ b/src/TurboServiceProvider.php
@@ -17,6 +17,7 @@ use Tonysm\TurboLaravel\Commands\TurboInstallCommand;
 use Tonysm\TurboLaravel\Facades\Turbo as TurboFacade;
 use Tonysm\TurboLaravel\Httpclass\PendingTurboStreamResponse;
 use Tonysm\TurboLaravel\Http\TurboResponseFactory;
+use Tonysm\TurboLaravel\Testing\AssertableTurboStream;
 
 class TurboServiceProvider extends ServiceProvider
 {
@@ -103,11 +104,17 @@ class TurboServiceProvider extends ServiceProvider
             return;
         }
 
-        TestResponse::macro('assertTurboStream', function () {
+        TestResponse::macro('assertTurboStream', function (callable $callback = null) {
             Assert::assertStringContainsString(
                 Turbo::TURBO_STREAM_FORMAT,
                 $this->headers->get('Content-Type'),
             );
+
+            if ($callback === null) {
+                return;
+            }
+
+            $callback(new AssertableTurboStream($this));
         });
 
         TestResponse::macro('assertNotTurboStream', function () {

--- a/tests/Http/TurboStreamResponseTest.php
+++ b/tests/Http/TurboStreamResponseTest.php
@@ -3,6 +3,7 @@
 namespace Tonysm\TurboLaravel\Tests\Http;
 
 use Illuminate\Support\Facades\View;
+use Tonysm\TurboLaravel\Testing\AssertableTurboStream;
 use Tonysm\TurboLaravel\Tests\TestCase;
 
 class TurboStreamResponseTest extends TestCase
@@ -33,5 +34,14 @@ class TurboStreamResponseTest extends TestCase
 
         $this->get(route('testing.non-turbo-stream'))
             ->assertNotTurboStream();
+    }
+
+    /** @test */
+    public function turbo_assert_count_of_turbo_streams()
+    {
+        $this->get(route('testing.turbo-stream'))
+            ->assertTurboStream(fn (AssertableTurboStream $turboStream) => (
+                $turboStream->has(3)
+            ));
     }
 }

--- a/tests/Http/TurboStreamResponseTest.php
+++ b/tests/Http/TurboStreamResponseTest.php
@@ -44,4 +44,27 @@ class TurboStreamResponseTest extends TestCase
                 $turboStream->has(3)
             ));
     }
+
+    /** @test */
+    public function turbo_assert_has_turbo_stream()
+    {
+        $this->get(route('testing.turbo-stream'))
+            ->assertTurboStream(fn (AssertableTurboStream $turboStreams) => (
+                $turboStreams->has(3)
+                && $turboStreams->hasTurboStream(fn ($turboStream) => (
+                    $turboStream->where('target', 'posts')
+                                ->where('action', 'append')
+                                ->see('Post Title')
+                ))
+                && $turboStreams->hasTurboStream(fn ($turboStream) => (
+                    $turboStream->where('target', 'inline_post_123')
+                                ->where('action', 'replace')
+                                ->see('Inline Post Title')
+                ))
+                && $turboStreams->hasTurboStream(fn ($turboStream) => (
+                    $turboStream->where('target', 'empty_posts')
+                                ->where('action', 'remove')
+                ))
+            ));
+    }
 }

--- a/tests/Http/TurboStreamResponseTest.php
+++ b/tests/Http/TurboStreamResponseTest.php
@@ -4,10 +4,13 @@ namespace Tonysm\TurboLaravel\Tests\Http;
 
 use Illuminate\Support\Facades\View;
 use Tonysm\TurboLaravel\Testing\AssertableTurboStream;
+use Tonysm\TurboLaravel\Testing\InteractsWithTurbo;
 use Tonysm\TurboLaravel\Tests\TestCase;
 
 class TurboStreamResponseTest extends TestCase
 {
+    use InteractsWithTurbo;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -18,28 +21,34 @@ class TurboStreamResponseTest extends TestCase
     protected function defineRoutes($router)
     {
         $router->get('/testing/turbo-stream', function () {
-            return response()->turboStreamView('turbo_streams');
-        })->name('testing.turbo-stream');
+            if (request()->wantsTurboStream()) {
+                return response()->turboStreamView('turbo_streams');
+            }
 
-        $router->get('/testing/non-turbo-stream', function () {
             return 'No Turbo Stream';
-        })->name('testing.non-turbo-stream');
+        })->name('testing.turbo-stream');
     }
 
     /** @test */
     public function turbo_stream_response()
     {
-        $this->get(route('testing.turbo-stream'))
+        $this->turbo()
+            ->get(route('testing.turbo-stream'))
             ->assertTurboStream();
+    }
 
-        $this->get(route('testing.non-turbo-stream'))
+    /** @test */
+    public function not_turbo_response()
+    {
+        $this->get(route('testing.turbo-stream'))
             ->assertNotTurboStream();
     }
 
     /** @test */
     public function turbo_assert_count_of_turbo_streams()
     {
-        $this->get(route('testing.turbo-stream'))
+        $this->turbo()
+            ->get(route('testing.turbo-stream'))
             ->assertTurboStream(fn (AssertableTurboStream $turboStream) => (
                 $turboStream->has(3)
             ));
@@ -48,7 +57,8 @@ class TurboStreamResponseTest extends TestCase
     /** @test */
     public function turbo_assert_has_turbo_stream()
     {
-        $this->get(route('testing.turbo-stream'))
+        $this->turbo()
+            ->get(route('testing.turbo-stream'))
             ->assertTurboStream(fn (AssertableTurboStream $turboStreams) => (
                 $turboStreams->has(3)
                 && $turboStreams->hasTurboStream(fn ($turboStream) => (

--- a/tests/Http/TurboStreamResponseTest.php
+++ b/tests/Http/TurboStreamResponseTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tonysm\TurboLaravel\Tests\Http;
+
+use Illuminate\Support\Facades\View;
+use Tonysm\TurboLaravel\Tests\TestCase;
+
+class TurboStreamResponseTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        View::addLocation(__DIR__ . '/../Stubs/views');
+    }
+
+    protected function defineRoutes($router)
+    {
+        $router->get('/testing/turbo-stream', function () {
+            return response()->turboStreamView('turbo_streams');
+        })->name('testing.turbo-stream');
+
+        $router->get('/testing/non-turbo-stream', function () {
+            return 'No Turbo Stream';
+        })->name('testing.non-turbo-stream');
+    }
+
+    /** @test */
+    public function turbo_stream_response()
+    {
+        $this->get(route('testing.turbo-stream'))
+            ->assertTurboStream();
+
+        $this->get(route('testing.non-turbo-stream'))
+            ->assertNotTurboStream();
+    }
+}

--- a/tests/Stubs/views/turbo_streams.blade.php
+++ b/tests/Stubs/views/turbo_streams.blade.php
@@ -1,6 +1,6 @@
 <turbo-stream target="posts" action="append">
     <template>
-        <div>
+        <div id="post_123">
             <h1>Post Title</h1>
             <p>Lorem Ipsum</p>
         </div>
@@ -15,4 +15,4 @@
     </template>
 </turbo-stream>
 
-<turbo-stream target="empty_posts" action="remote"></turbo-stream>
+<turbo-stream target="empty_posts" action="remove"></turbo-stream>

--- a/tests/Stubs/views/turbo_streams.blade.php
+++ b/tests/Stubs/views/turbo_streams.blade.php
@@ -1,0 +1,18 @@
+<turbo-stream target="posts" action="append">
+    <template>
+        <div>
+            <h1>Post Title</h1>
+            <p>Lorem Ipsum</p>
+        </div>
+    </template>
+</turbo-stream>
+
+<turbo-stream target="inline_post_123" action="replace">
+    <template>
+        <div>
+            <h1>Inline Post Title</h1>
+        </div>
+    </template>
+</turbo-stream>
+
+<turbo-stream target="empty_posts" action="remote"></turbo-stream>

--- a/tests/Testing/TurboStreamMatcherTest.php
+++ b/tests/Testing/TurboStreamMatcherTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tonysm\TurboLaravel\Tests\Testing;
+
+use Illuminate\Testing\TestResponse;
+use PHPUnit\Framework\ExpectationFailedException;
+use Tonysm\TurboLaravel\Testing\ConvertTestResponseToTurboStreamCollection;
+use Tonysm\TurboLaravel\Testing\TurboStreamMatcher;
+use Tonysm\TurboLaravel\Tests\TestCase;
+
+class TurboStreamMatcherTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->response = new TestResponse(response(<<<html
+        <turbo-stream action="append" target="item_1">
+            <template>
+                <h1>First Item</h1>
+            </template>
+        </turbo-stream>
+
+        <turbo-stream action="append" target="item_2">
+            <template>
+                <h1>Second Item</h1>
+            </template>
+        </turbo-stream>
+
+        <turbo-stream action="remove" target="item_3">
+        </turbo-stream>
+        html));
+
+        $this->streams = (new ConvertTestResponseToTurboStreamCollection)($this->response)->mapInto(TurboStreamMatcher::class);
+    }
+
+    /** @test */
+    public function converts_streams_to_collections()
+    {
+        $this->assertCount(3, $this->streams);
+    }
+
+    /** @test */
+    public function filters_by_attributes()
+    {
+        $appends = $this->streams->filter(fn (TurboStreamMatcher $matcher) => (
+            $matcher->where('action', 'append')->matches()
+        ));
+
+        $this->assertCount(2, $appends);
+
+        $appends = $appends->filter(fn (TurboStreamMatcher $matcher) => (
+            $matcher->where('target', 'item_2')->matches()
+        ));
+
+        $this->assertCount(1, $appends);
+
+        // Both action and target attributes.
+        $this->streams->filter(fn (TurboStreamMatcher $matcher) => (
+            $matcher->where('action', 'remove')
+                ->where('target', 'item_3')
+                ->matches()
+        ));
+    }
+
+    /** @test */
+    public function can_see_text()
+    {
+        $firstItem = $this->streams->filter(fn (TurboStreamMatcher $matcher) => (
+            $matcher->where('action', 'append')
+                ->where('target', 'item_1')
+                ->see('First Item')
+                ->matches()
+        ));
+
+        $this->assertCount(1, $firstItem);
+    }
+
+    /** @test */
+    public function fails_when_string_doesnt_match()
+    {
+        try {
+            $this->streams->filter(fn (TurboStreamMatcher $matcher) => (
+                $matcher->where('action', 'append')
+                    ->where('target', 'item_1')
+                    ->see('Second Item')
+                    ->matches()
+            ));
+
+            $this->fail('Should have failed to match the text, but did not.');
+        } catch (ExpectationFailedException $_e) {
+            return;
+        }
+    }
+}


### PR DESCRIPTION
### Added

- Adds the `$response->assertTurboStream` macro which accepts an optional callback that receives an object of the `AssertableTurboStream` class, which should give developers some methods like `->has(3)` which asserts that there are 3 turbo stream tags, and a `->hasTurboStream(fn)` which receives a callback so you can filter and match the Turbo Stream you want check that is present, this one receives a callback and you can chain `->where()` calls to each turbo stream and also chain a `->see()` and other regular Laravel assertions on the contents of the template inside these turbo streams (make sure you call `->see()` after your `->where()` filters).

### Changed

- Pulls the Turbo.js version `^7.0.0-beta.8` for fresh installs.

---

Todo:

- [x] Update documentation
- [x] Clean up code and add comments where needed
- [x] Deprecate the testing package (not needed anymore)