### PR TITLE
Adds the wasFromTurboNative request macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,13 +697,21 @@ Alternatively, you can check if it's not a Turbo Native visit using the `@unless
 @endunlessturbonative
 ```
 
-You may also check if the request was made from a Turbo Native visit using the TurboFacade, like so:
+You may also check if the request was made from a Turbo Native visit using the request macro:
+
+```php
+if (request()->wasFromTurboNative()) {
+    // ...
+}
+```
+
+Or the Turbo Facade directly, like so:
 
 ```php
 use Tonysm\TurboLaravel\Facades\Turbo;
 
 if (Turbo::isTurboNativeVisit()) {
-    // Do something for mobile specific requests.
+    // ...
 }
 ```
 

--- a/src/TurboServiceProvider.php
+++ b/src/TurboServiceProvider.php
@@ -97,6 +97,10 @@ class TurboServiceProvider extends ServiceProvider
         Request::macro('wantsTurboStream', function () {
             return Str::contains($this->header('Accept'), Turbo::TURBO_STREAM_FORMAT);
         });
+
+        Request::macro('wasFromTurboNative', function () {
+            return TurboFacade::isTurboNativeVisit();
+        });
     }
 
     protected function bindTestResponseMacros()

--- a/tests/Http/RequestMacrosTest.php
+++ b/tests/Http/RequestMacrosTest.php
@@ -23,7 +23,7 @@ class RequestMacrosTest extends TestCase
     }
 
     /** @test */
-    public function was_from_turbo_stream()
+    public function was_from_turbo_native()
     {
         $request = Request::create('/hello');
         $this->assertFalse($request->wasFromTurboNative());

--- a/tests/Http/RequestMacrosTest.php
+++ b/tests/Http/RequestMacrosTest.php
@@ -3,6 +3,7 @@
 namespace Tonysm\TurboLaravel\Tests\Http;
 
 use Illuminate\Http\Request;
+use Tonysm\TurboLaravel\Facades\Turbo as TurboFacade;
 use Tonysm\TurboLaravel\Tests\TestCase;
 use Tonysm\TurboLaravel\Turbo;
 
@@ -19,5 +20,15 @@ class RequestMacrosTest extends TestCase
             'Accept' => Turbo::TURBO_STREAM_FORMAT.', text/html, application/xhtml+xml',
         ]);
         $this->assertTrue($request->wantsTurboStream(), 'Expected request to want a turbo stream response, but it did not.');
+    }
+
+    /** @test */
+    public function was_from_turbo_stream()
+    {
+        $request = Request::create('/hello');
+        $this->assertFalse($request->wasFromTurboNative());
+
+        TurboFacade::setVisitingFromTurboNative();
+        $this->assertTrue($request->wasFromTurboNative());
     }
 }


### PR DESCRIPTION
### Added

- Adds the `request()->wasFromTurboNative()` macro, which can be used in content negotiation