### PR TITLE
Change the default invalid form handling to follow redirects internally

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ php artisan turbo:install --jet --stimulus
 
 The package ships with a middleware which applies some conventions on your redirects, specially around how failed validations are handled automatically by Laravel. Read more about this in the [Conventions](#conventions) section of the documentation.
 
-You may add the middleware to the "web" route group on your HTTP Kernel:
+**The middleware is automatically prepended to your web route group middleware stack**. You may want to add the middleware to other groups, when doing so, make sure it's at the top of the middleware stack:
 
 ```php
 \Tonysm\TurboLaravel\Http\Middleware\TurboMiddleware::class,
@@ -90,8 +90,8 @@ class Kernel extends HttpKernel
 {
     protected $middlewareGroups = [
         'web' => [
-            // ...
             \Tonysm\TurboLaravel\Http\Middleware\TurboMiddleware::class,
+            // other middlewares...
         ],
     ];
 }

--- a/src/Facades/Turbo.php
+++ b/src/Facades/Turbo.php
@@ -17,6 +17,8 @@ use Tonysm\TurboLaravel\Turbo as BaseTurbo;
  * @method static bool shouldBroadcastToOthers
  * @method static string domId(Model $model, string $prefix = "")
  * @method static Broadcaster broadcaster()
+ * @method static self withoutRegisteringMiddleware()
+ * @method static bool shouldRegisterMiddleware()
  */
 class Turbo extends Facade
 {

--- a/src/Http/Middleware/RouteRedirectGuesser.php
+++ b/src/Http/Middleware/RouteRedirectGuesser.php
@@ -6,8 +6,12 @@ use Illuminate\Support\Str;
 
 class RouteRedirectGuesser
 {
-    public function guess(string $routeName): string
+    public function guess(string $routeName): ?string
     {
+        if (! Str::endsWith($routeName, '.store') && ! Str::endsWith($routeName, '.update')) {
+            return null;
+        }
+
         $creating = Str::endsWith($routeName, '.store');
 
         $lookFor = $creating

--- a/src/Http/Middleware/TurboMiddleware.php
+++ b/src/Http/Middleware/TurboMiddleware.php
@@ -89,16 +89,13 @@ class TurboMiddleware
      *
      * @return Response
      */
-    protected function handleRedirectInternally(Kernel $kernel, string $url, $previousRequest)
+    protected function handleRedirectInternally(Kernel $kernel, string $url, $request)
     {
-        /** @param Response|RedirectResponse $response */
-        $response = $kernel->handle(
-            $request = $this->createRequestFrom($url, $previousRequest)
-        );
-
-        if ($response->isRedirect()) {
-            return $this->handleRedirectInternally($kernel, $response->getTargetUrl(), $request);
-        }
+        do {
+            $response = $kernel->handle(
+                $request = $this->createRequestFrom($url, $request)
+            );
+        } while ($response->isRedirect());
 
         return $response->setStatusCode(422);
     }

--- a/src/Http/Middleware/TurboMiddleware.php
+++ b/src/Http/Middleware/TurboMiddleware.php
@@ -104,7 +104,7 @@ class TurboMiddleware
         return $response->setStatusCode(422);
     }
 
-    public function createRequestFrom(string $url, $baseRequest)
+    protected function createRequestFrom(string $url, $baseRequest)
     {
         $request = Request::create($url);
 

--- a/src/Http/Middleware/TurboMiddleware.php
+++ b/src/Http/Middleware/TurboMiddleware.php
@@ -67,9 +67,7 @@ class TurboMiddleware
         // the form route for the current endpoint, make an internal request there, and return the
         // response body with the form over a 422 status code, which is better for Turbo Native.
 
-        $formRedirectUrl = $this->guessFormRedirectUrl($request);
-
-        if ($formRedirectUrl && $response->exception instanceof ValidationException && ! $response->exception->redirectTo) {
+        if ($response->exception instanceof ValidationException && ($formRedirectUrl = $this->getRedirectUrl($request, $response))) {
             return tap($this->handleRedirectInternally($this->kernel(), $formRedirectUrl, $request), function () use ($request) {
                 App::instance('request', $request);
                 Facade::clearResolvedInstance('request');
@@ -79,6 +77,15 @@ class TurboMiddleware
         $response->setStatusCode(303);
 
         return $response;
+    }
+
+    protected function getRedirectUrl($request, $response)
+    {
+        if ($response->exception->redirectTo) {
+            return $response->exception->redirectTo;
+        }
+
+        return $this->guessFormRedirectUrl($request);
     }
 
     protected function kernel(): Kernel

--- a/src/Http/Middleware/TurboMiddleware.php
+++ b/src/Http/Middleware/TurboMiddleware.php
@@ -145,7 +145,7 @@ class TurboMiddleware
 
         // If the guessed route doesn't exist, send it back to wherever Laravel defaults to.
 
-        if (! Route::has($formRouteName)) {
+        if (! $formRouteName || ! Route::has($formRouteName)) {
             return null;
         }
 

--- a/src/Turbo.php
+++ b/src/Turbo.php
@@ -54,6 +54,7 @@ class Turbo
     {
         return $this->registerMiddleware;
     }
+
     /**
      * @param bool|Closure $toOthers
      *

--- a/src/Turbo.php
+++ b/src/Turbo.php
@@ -24,6 +24,13 @@ class Turbo
      */
     private bool $broadcastToOthersOnly = false;
 
+    /**
+     * Whether or not the turbo middleware should be automatically added to the "web" middleware group stack.
+     *
+     * @var bool
+     */
+    private bool $registerMiddleware = true;
+
     public function isTurboNativeVisit(): bool
     {
         return $this->visitFromTurboNative;
@@ -36,6 +43,17 @@ class Turbo
         return $this;
     }
 
+    public function withoutRegisteringMiddleware(): self
+    {
+        $this->registerMiddleware = true;
+
+        return $this;
+    }
+
+    public function shouldRegisterMiddleware(): bool
+    {
+        return $this->registerMiddleware;
+    }
     /**
      * @param bool|Closure $toOthers
      *

--- a/src/TurboServiceProvider.php
+++ b/src/TurboServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Response;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;
@@ -15,6 +16,7 @@ use Tonysm\TurboLaravel\Broadcasters\Broadcaster;
 use Tonysm\TurboLaravel\Broadcasters\LaravelBroadcaster;
 use Tonysm\TurboLaravel\Commands\TurboInstallCommand;
 use Tonysm\TurboLaravel\Facades\Turbo as TurboFacade;
+use Tonysm\TurboLaravel\Http\Middleware\TurboMiddleware;
 use Tonysm\TurboLaravel\Http\PendingTurboStreamResponse;
 use Tonysm\TurboLaravel\Http\TurboResponseFactory;
 use Tonysm\TurboLaravel\Testing\AssertableTurboStream;
@@ -43,6 +45,8 @@ class TurboServiceProvider extends ServiceProvider
         $this->bindBladeMacros();
         $this->bindRequestAndResponseMacros();
         $this->bindTestResponseMacros();
+
+        Route::prependMiddlewareToGroup('web', TurboMiddleware::class);
     }
 
     public function register()

--- a/src/TurboServiceProvider.php
+++ b/src/TurboServiceProvider.php
@@ -46,7 +46,9 @@ class TurboServiceProvider extends ServiceProvider
         $this->bindRequestAndResponseMacros();
         $this->bindTestResponseMacros();
 
-        Route::prependMiddlewareToGroup('web', TurboMiddleware::class);
+        if (TurboFacade::shouldRegisterMiddleware()) {
+            Route::prependMiddlewareToGroup('web', TurboMiddleware::class);
+        }
     }
 
     public function register()

--- a/tests/Http/Middleware/TurboMiddlewareTest.php
+++ b/tests/Http/Middleware/TurboMiddlewareTest.php
@@ -15,7 +15,7 @@ class TurboMiddlewareTest extends TestCase
     public function usesTestModelResourceRoutes()
     {
         Route::get('/test-models/create', function () {
-            return 'show form';
+            return 'show create form' . (request()->has('frame') ? ' (frame=' . request('frame') . ')' : '');
         })->name('test-models.create');
 
         Route::post('/test-models', function () {
@@ -23,7 +23,7 @@ class TurboMiddlewareTest extends TestCase
         })->name('test-models.store')->middleware(TurboMiddleware::class);
 
         Route::get('/test-models/{testModel}/edit', function () {
-            return 'show form';
+            return 'show edit form' . (request()->has('frame') ? ' (frame=' . request('frame') . ')' : '');
         })->name('test-models.edit');
 
         Route::put('/test-models/{testModel}', function (TestModel $model) {
@@ -47,14 +47,14 @@ class TurboMiddlewareTest extends TestCase
      * @test
      * @define-route usesTestModelResourceRoutes
      */
-    public function handles_redirect_responses()
+    public function handles_invalid_forms_with_an_internal_redirect()
     {
         $response = $this->from('/source')->post('/test-models', [], [
             'Accept' => sprintf('%s, text/html, application/xhtml+xml', Turbo::TURBO_STREAM_FORMAT),
         ]);
 
-        $response->assertRedirect('/test-models/create');
-        $response->assertStatus(303);
+        $response->assertSee('show create form');
+        $response->assertStatus(422);
     }
 
     public function usesTurboNativeRoute()
@@ -96,7 +96,7 @@ class TurboMiddlewareTest extends TestCase
         })->name('somewhere-else');
 
         Route::get('/test-models/create', function () {
-            return 'show form';
+            return 'show create form' . (request()->has('frame') ? ' (frame=' . request('frame') . ')' : '');
         })->name('test-models.create');
 
         Route::post('/test-models', function () {
@@ -122,14 +122,14 @@ class TurboMiddlewareTest extends TestCase
      * @test
      * @define-route usesTestModelResourceRoutes
      */
-    public function redirects_back_to_resource_create_routes_on_failed_validation_follows_laravel_conventions()
+    public function sends_an_internal_redirect_to_resource_create_routes_on_failed_validation_follows_laravel_conventions_and_returns_422_status_code()
     {
         $response = $this->from('/source')->post(route('test-models.store'), [], [
             'Accept' => sprintf('%s, text/html, application/xhtml+xml', Turbo::TURBO_STREAM_FORMAT),
         ]);
 
-        $response->assertRedirect(route('test-models.create'));
-        $response->assertStatus(303);
+        $response->assertSee('show create form');
+        $response->assertStatus(422);
     }
 
     /**
@@ -144,8 +144,8 @@ class TurboMiddlewareTest extends TestCase
             'Accept' => sprintf('%s, text/html, application/xhtml+xml', Turbo::TURBO_STREAM_FORMAT),
         ]);
 
-        $response->assertRedirect(route('test-models.edit', $testModel));
-        $response->assertStatus(303);
+        $response->assertSee('show edit form');
+        $response->assertStatus(422);
     }
 
     /**
@@ -160,8 +160,8 @@ class TurboMiddlewareTest extends TestCase
             'Accept' => sprintf('%s, text/html, application/xhtml+xml', Turbo::TURBO_STREAM_FORMAT),
         ]);
 
-        $response->assertRedirect(route('test-models.edit', ['testModel' => $testModel, 'frame' => 'lorem']));
-        $response->assertStatus(303);
+        $response->assertSee('show edit form (frame=lorem)');
+        $response->assertStatus(422);
     }
 
     public function usesTestModelUpdateRouteWithoutEdit()

--- a/tests/Http/Middleware/TurboMiddlewareTest.php
+++ b/tests/Http/Middleware/TurboMiddlewareTest.php
@@ -186,4 +186,35 @@ class TurboMiddlewareTest extends TestCase
         $response->assertRedirect('/source');
         $response->assertStatus(303);
     }
+
+    public function usesNonResourceRoutes()
+    {
+        Route::name('app.')->middleware(TurboMiddleware::class)->group(function () {
+            Route::get('login', function () {
+                return 'login form';
+            })->name('login');
+
+            Route::post('login', function () {
+                request()->validate([
+                    'email' => 'required',
+                    'password' => 'required',
+                ]);
+            });
+        });
+    }
+
+    /**
+     * @test
+     * @define-route usesNonResourceRoutes
+     */
+    public function only_guess_route_on_resource_routes()
+    {
+        $this->from(route('app.login'))
+            ->withHeaders([
+                'Accept' => sprintf('%s, text/html, application/xhtml+xml', Turbo::TURBO_STREAM_FORMAT),
+            ])
+            ->post('/login')
+            ->assertRedirect(route('app.login'))
+            ->assertStatus(303);
+    }
 }

--- a/tests/Http/Middleware/TurboMiddlewareTest.php
+++ b/tests/Http/Middleware/TurboMiddlewareTest.php
@@ -114,8 +114,8 @@ class TurboMiddlewareTest extends TestCase
             'Accept' => sprintf('%s, text/html, application/xhtml+xml', Turbo::TURBO_STREAM_FORMAT),
         ]);
 
-        $response->assertRedirect('/somewhere-else');
-        $response->assertStatus(303);
+        $response->assertSee('show form');
+        $response->assertStatus(422);
     }
 
     /**


### PR DESCRIPTION
### Changed

- Instead of redirecting to the form route when a `ValidationException` is thrown, we're following the redirects internally returning the form response body with a 422 status code, which is better handled by Turbo Native.

---

Issue #29 

This borrows from the [Inertia dialog implementation](https://github.com/inertiajs/inertia-laravel/commit/35367f0b2ff68822e27185f49ddfa5dd7846386e).