### PR TITLE
Bring back Laravel 8 builds

### DIFF
--- a/.github/workflows/run-tests-l8.yml
+++ b/.github/workflows/run-tests-l8.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   test:

--- a/.github/workflows/run-tests-l8.yml
+++ b/.github/workflows/run-tests-l8.yml
@@ -10,11 +10,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.0, 8.1]
-        laravel: [9.*]
+        laravel: [8.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: "^7.0"
+          - laravel: 8.*
+            testbench: "^6.24"
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests-l8.yml
+++ b/.github/workflows/run-tests-l8.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Tests L8
 
 on: [push]
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   test:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,9 +9,12 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.0]
-        laravel: [9.*]
+        php: [8.0, 8.1]
+        laravel: [8.*, 9.*]
         stability: [prefer-lowest, prefer-stable]
+      include:
+        - laravel: "^8.47"
+          testbench: "^6.24"
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -33,6 +36,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,8 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,9 +12,9 @@ jobs:
         php: [8.0, 8.1]
         laravel: [8.*, 9.*]
         stability: [prefer-lowest, prefer-stable]
-      include:
-        - laravel: "^8.47"
-          testbench: "^6.24"
+        include:
+          - laravel: "^8.47"
+            testbench: "^6.24"
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,9 @@ jobs:
         laravel: [8.*, 9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: "^8.47"
+          - laravel: 9.*
+            testbench: "^7.0"
+          - laravel: 8.*
             testbench: "^6.24"
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     ],
     "require": {
         "php": "^8.0|^8.1",
-        "illuminate/support": "^9.0"
+        "illuminate/support": "^8.47|^9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0",
+        "orchestra/testbench": "^6.24|^7.0",
         "phpunit/phpunit": "^9.5"
     },
     "autoload": {

--- a/tests/Http/ResponseMacrosTest.php
+++ b/tests/Http/ResponseMacrosTest.php
@@ -5,7 +5,6 @@ namespace Tonysm\TurboLaravel\Tests\Http;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\HtmlString;
 
@@ -284,9 +283,7 @@ class ResponseMacrosTest extends TestCase
     {
         $response = response()
             ->turboStream()
-            ->append('some_dom_id', new HtmlString(
-                Blade::render('<div>Hello, {{ $name }}</div>', ['name' => 'Tester'], deleteCachedView: true)
-            ))
+            ->append('some_dom_id', new HtmlString('<div>Hello, Tester</div>'))
             ->toResponse(new Request);
 
         $expected = <<<HTML


### PR DESCRIPTION
### Fixed

- While I was working on some upgrades, I dropped Laravel and PHP versions requirements, but I haven't tagged a major version, so I'm bringing it back