### PR TITLE
Implement streams Targeting Multiple Elements

### DIFF
--- a/resources/views/components/stream.blade.php
+++ b/resources/views/components/stream.blade.php
@@ -1,4 +1,4 @@
-<turbo-stream target="{{ $targetValue }}" action="{{ $action }}">
+<turbo-stream @if(isset($targets))targets=@else{{''}}target=@endif"{{ $targetValue }}" action="{{ $action }}">
 @if ($action !== "remove")
     <template>{{ $slot }}</template>
 @endif

--- a/resources/views/turbo-stream.blade.php
+++ b/resources/views/turbo-stream.blade.php
@@ -1,4 +1,4 @@
-<x-turbo-stream :target="$target" :action="$action">
+<x-turbo-stream :target="$target ?? null" :action="$action" :targets="$targets ?? null">
 @if ($partial ?? false)
     @include($partial, $partialData)
 @elseif ($content ?? false)

--- a/src/Broadcasters/Broadcaster.php
+++ b/src/Broadcasters/Broadcaster.php
@@ -9,19 +9,21 @@ interface Broadcaster
     /**
      * @param Channel[] $channels
      * @param bool $later
-     * @param string $target
+     * @param ?string $target
      * @param string $action
      * @param ?string $partial = null
      * @param ?array $partialData = []
      * @param ?string $exceptSocket = null
+     * @param ?string $targets = null
      */
     public function broadcast(
         array $channels,
         bool $later,
-        string $target,
+        ?string $target,
         string $action,
         ?string $partial = null,
         ?array $partialData = [],
-        ?string $exceptSocket = null
+        ?string $exceptSocket = null,
+        ?string $targets = null
     ): void;
 }

--- a/src/Broadcasters/LaravelBroadcaster.php
+++ b/src/Broadcasters/LaravelBroadcaster.php
@@ -10,20 +10,22 @@ class LaravelBroadcaster implements Broadcaster
     /**
      * @param Channel[] $channels
      * @param bool $later
-     * @param string $target
+     * @param ?string $target
      * @param string $action
      * @param ?string $partial = null
      * @param ?array $partialData = []
      * @param ?string $exceptSocket = null
+     * @param ?string $targets = null
      */
     public function broadcast(
         array $channels,
         bool $later,
-        string $target,
+        ?string $target,
         string $action,
         ?string $partial = null,
         ?array $partialData = [],
-        ?string $exceptSocket = null
+        ?string $exceptSocket = null,
+        ?string $targets = null
     ): void {
         $job = new BroadcastAction(
             $channels,
@@ -32,6 +34,7 @@ class LaravelBroadcaster implements Broadcaster
             $partial,
             $partialData,
             $exceptSocket,
+            $targets
         );
 
         if ($later) {

--- a/src/Broadcasting/PendingBroadcast.php
+++ b/src/Broadcasting/PendingBroadcast.php
@@ -12,19 +12,21 @@ class PendingBroadcast
     /** @var Channel[] */
     public array $channels;
     public string $action;
-    public string $target;
+    public ?string $target;
     public ?string $partialView = null;
     public ?array $partialData = [];
     public bool $sendToOthers = false;
     public bool $sendLater = false;
+    public ?string $targets = null;
 
-    public function __construct(array $channels, string $action, string $target, Rendering $rendering)
+    public function __construct(array $channels, string $action, ?string $target, Rendering $rendering, ?string $targets = null)
     {
         $this->channels = $channels;
         $this->action = $action;
         $this->target = $target;
         $this->partialView = $rendering->partial;
         $this->partialData = $rendering->data;
+        $this->targets = null;
     }
 
     public function to($channel): self
@@ -44,6 +46,15 @@ class PendingBroadcast
     public function target(string $target): self
     {
         $this->target = $target;
+        $this->targets = null;
+
+        return $this;
+    }
+
+    public function targets(string $targets): self
+    {
+        $this->targets = $targets;
+        $this->target = null;
 
         return $this;
     }
@@ -86,6 +97,7 @@ class PendingBroadcast
             $this->partialView,
             $this->partialData,
             $socket,
+            $this->targets
         );
     }
 }

--- a/src/Events/TurboStreamBroadcast.php
+++ b/src/Events/TurboStreamBroadcast.php
@@ -13,18 +13,20 @@ class TurboStreamBroadcast implements ShouldBroadcastNow
 
     /** @var Channel[] */
     public array $channels;
-    public string $target;
+    public ?string $target;
     public string $action;
     public ?string $partial = null;
     public ?array $partialData = [];
+    public ?string $targets = null;
 
-    public function __construct(array $channels, string $target, string $action, ?string $partial = null, ?array $partialData = [])
+    public function __construct(array $channels, ?string $target, string $action, ?string $partial = null, ?array $partialData = [], ?string $targets = null)
     {
         $this->channels = $channels;
         $this->target = $target;
         $this->action = $action;
         $this->partial = $partial;
         $this->partialData = $partialData;
+        $this->targets = $targets;
     }
 
     public function broadcastOn()
@@ -46,6 +48,7 @@ class TurboStreamBroadcast implements ShouldBroadcastNow
             'action' => $this->action,
             'partial' => $this->partial ?: null,
             'partialData' => $this->partialData ?: [],
+            'targets' => $this->targets,
         ])->render();
     }
 }

--- a/src/Jobs/BroadcastAction.php
+++ b/src/Jobs/BroadcastAction.php
@@ -13,13 +13,14 @@ class BroadcastAction implements ShouldQueue
     use SerializesModels;
 
     public array $channels;
-    public string $target;
+    public ?string $target;
     public string $action;
     public ?string $partial;
     public ?array $partialData;
     public ?string $socket;
+    public ?string $targets;
 
-    public function __construct(array $channels, string $target, string $action, ?string $partial = null, ?array $partialData = [], $socket = null)
+    public function __construct(array $channels, ?string $target, string $action, ?string $partial = null, ?array $partialData = [], $socket = null, $targets = null)
     {
         $this->channels = $channels;
         $this->target = $target;
@@ -27,6 +28,7 @@ class BroadcastAction implements ShouldQueue
         $this->partial = $partial;
         $this->partialData = $partialData;
         $this->socket = $socket;
+        $this->targets = $targets;
     }
 
     public function handle()
@@ -41,7 +43,8 @@ class BroadcastAction implements ShouldQueue
             $this->target,
             $this->action,
             $this->partial,
-            $this->partialData
+            $this->partialData,
+            $this->targets
         );
 
         $event->socket = $this->socket;

--- a/src/Views/Components/Stream.php
+++ b/src/Views/Components/Stream.php
@@ -9,22 +9,34 @@ use function Tonysm\TurboLaravel\dom_id;
 
 class Stream extends Component
 {
-    /** @var string|Model|array */
-    public $target;
+    public string|Model|array|null $target;
 
-    public string $action;
+    public ?string $action;
+
+    public ?string $targets;
 
     /**
      * Create a new component instance.
      *
-     * @param string|Model|array $target The DOM ID string, a model to generate the DOM ID for, or an array to be passed to the `dom_id` function.
-     * @param string $action One of the seven Turbo Stream actions: "append", "prepend", "before", "after", "replace", "update", or "remove".
-     * @return void
+     * @param string|Model|array|null $target The DOM ID string, a model to generate the DOM ID for, or an array to be passed to the `dom_id` function.
+     * @param ?string $action One of the seven Turbo Stream actions: "append", "prepend", "before", "after", "replace", "update", or "remove".
+     * @param string|null $targets The CSS selector to apply the action to multiple targets
      */
-    public function __construct($target, string $action)
+    public function __construct(string|Model|array|null $target = null, ?string $action = null, ?string $targets = null)
     {
         $this->target = $target;
         $this->action = $action;
+        $this->targets = $targets;
+        if (!$action) {
+            throw new \InvalidArgumentException('Action is required');
+        }
+        if (!$target && !$targets) {
+            throw new \InvalidArgumentException('targets and target cannot be both null');
+        }
+
+        if ($target && $targets) {
+            throw new \InvalidArgumentException('targets and target are both set. One needs to be null');
+        }
     }
 
     /**
@@ -41,6 +53,10 @@ class Stream extends Component
 
     private function targetValue(): string
     {
+        if (isset($this->targets)){
+            return $this->targets;
+        }
+
         if (is_string($this->target)) {
             return $this->target;
         }

--- a/tests/Events/TurboStreamBroadcastTest.php
+++ b/tests/Events/TurboStreamBroadcastTest.php
@@ -40,4 +40,30 @@ class TurboStreamBroadcastTest extends TestCase
 
         $this->assertEquals(trim($expected), trim($rendered));
     }
+
+    /** @test */
+    public function renders_turbo_stream_targets()
+    {
+        $event = new TurboStreamBroadcast(
+            [],
+            null,
+            'replace',
+            'test_models._test_model',
+            ['testModel' => new TestModel(['id' => 1])],
+            'targets'
+        );
+
+        $expected = View::make('turbo-laravel::turbo-stream', [
+            'targets' => 'targets',
+            'action' => 'replace',
+            'partial' => 'test_models._test_model',
+            'partialData' => [
+                'testModel' => new TestModel(['id' => 1]),
+            ],
+        ]);
+
+        $rendered = $event->render();
+
+        $this->assertEquals(trim($expected), trim($rendered));
+    }
 }

--- a/tests/Http/ResponseMacrosTest.php
+++ b/tests/Http/ResponseMacrosTest.php
@@ -593,6 +593,24 @@ class ResponseMacrosTest extends TestCase
     }
 
     /** @test */
+    public function targets()
+    {
+        $response = response()
+            ->turboStream()
+            ->targets('test_targets')
+            ->remove('test_models_target')
+            ->toResponse(new Request);
+
+        $expected = view('turbo-laravel::turbo-stream', [
+            'action' => 'remove',
+            'targets' => 'test_targets',
+        ])->render();
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
     public function builds_multiple_turbo_stream_responses()
     {
         $model = TestModel::create(['name' => 'Test model']);

--- a/tests/Http/TurboStreamResponseTest.php
+++ b/tests/Http/TurboStreamResponseTest.php
@@ -50,7 +50,7 @@ class TurboStreamResponseTest extends TestCase
         $this->turbo()
             ->get(route('testing.turbo-stream'))
             ->assertTurboStream(fn (AssertableTurboStream $turboStream) => (
-                $turboStream->has(3)
+                $turboStream->has(4)
             ));
     }
 
@@ -60,7 +60,7 @@ class TurboStreamResponseTest extends TestCase
         $this->turbo()
             ->get(route('testing.turbo-stream'))
             ->assertTurboStream(fn (AssertableTurboStream $turboStreams) => (
-                $turboStreams->has(3)
+                $turboStreams->has(4)
                 && $turboStreams->hasTurboStream(fn ($turboStream) => (
                     $turboStream->where('target', 'posts')
                                 ->where('action', 'append')
@@ -74,6 +74,10 @@ class TurboStreamResponseTest extends TestCase
                 && $turboStreams->hasTurboStream(fn ($turboStream) => (
                     $turboStream->where('target', 'empty_posts')
                                 ->where('action', 'remove')
+                ))
+                && $turboStreams->hasTurboStream(fn ($turboStream) => (
+                $turboStream->where('targets', '.post')
+                    ->where('action', 'replace')
                 ))
             ));
     }

--- a/tests/Stubs/views/turbo_streams.blade.php
+++ b/tests/Stubs/views/turbo_streams.blade.php
@@ -16,3 +16,11 @@
 </turbo-stream>
 
 <turbo-stream target="empty_posts" action="remove"></turbo-stream>
+
+<turbo-stream targets=".post" action="replace">
+    <template>
+        <div>
+            <h2>Replaced all post</h2>
+        </div>
+    </template>
+</turbo-stream>

--- a/tests/Testing/TurboStreamMatcherTest.php
+++ b/tests/Testing/TurboStreamMatcherTest.php
@@ -29,6 +29,12 @@ class TurboStreamMatcherTest extends TestCase
 
         <turbo-stream action="remove" target="item_3">
         </turbo-stream>
+
+        <turbo-stream action="replace" targets=".items">
+            <template>
+                <h1>new Item</h1>
+            </template>
+        </turbo-stream>
         html));
 
         $this->streams = (new ConvertTestResponseToTurboStreamCollection)($this->response)->mapInto(TurboStreamMatcher::class);
@@ -37,30 +43,37 @@ class TurboStreamMatcherTest extends TestCase
     /** @test */
     public function converts_streams_to_collections()
     {
-        $this->assertCount(3, $this->streams);
+        $this->assertCount(4, $this->streams);
     }
 
     /** @test */
     public function filters_by_attributes()
     {
         $appends = $this->streams->filter(fn (TurboStreamMatcher $matcher) => (
-            $matcher->where('action', 'append')->matches()
+            (clone $matcher)->where('action', 'append')->matches()
         ));
 
         $this->assertCount(2, $appends);
 
         $appends = $appends->filter(fn (TurboStreamMatcher $matcher) => (
-            $matcher->where('target', 'item_2')->matches()
+            (clone $matcher)->where('target', 'item_2')->matches()
         ));
 
         $this->assertCount(1, $appends);
 
         // Both action and target attributes.
-        $this->streams->filter(fn (TurboStreamMatcher $matcher) => (
-            $matcher->where('action', 'remove')
+        $remove_item_3 = $this->streams->filter(fn (TurboStreamMatcher $matcher) => (
+            (clone $matcher)->where('action', 'remove')
                 ->where('target', 'item_3')
                 ->matches()
         ));
+
+        $this->assertCount(1, $remove_item_3);
+
+        $targets = $this->streams->filter(fn (TurboStreamMatcher $matcher) => (
+            (clone $matcher)->where('targets', '.items')->matches()
+        ));
+        $this->assertCount(1, $targets);
     }
 
     /** @test */

--- a/tests/Views/ComponentsTest.php
+++ b/tests/Views/ComponentsTest.php
@@ -3,6 +3,7 @@
 namespace Tonysm\TurboLaravel\Tests\Views;
 
 use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
+use Illuminate\View\ViewException;
 use Tonysm\TurboLaravel\Tests\Stubs\Models\TestModel;
 use Tonysm\TurboLaravel\Tests\TestCase;
 
@@ -72,7 +73,8 @@ class ComponentsTest extends TestCase
             ->assertSee('target="todos"', false)
             ->assertSee('action="append"', false)
             ->assertSee('<template><p>Hello, World</p></template>', false)
-            ->assertSee('</turbo-stream>', false);
+            ->assertSee('</turbo-stream>', false)
+            ->assertDontSee('targets=');
 
         $this->blade(<<<'BLADE'
             <x-turbo-stream :target="[$model, 'comments']" action="append">
@@ -83,7 +85,8 @@ class ComponentsTest extends TestCase
             ->assertSee('target="comments_test_model_123"', false)
             ->assertSee('action="append"', false)
             ->assertSee('<template><p>Hello, World</p></template>', false)
-            ->assertSee('</turbo-stream>', false);
+            ->assertSee('</turbo-stream>', false)
+            ->assertDontSee('targets=');
 
         // Stream content is ignore when action is set to "remove"...
         $this->blade(<<<'BLADE'
@@ -97,7 +100,20 @@ class ComponentsTest extends TestCase
             ->assertDontSee('<template>', false)
             ->assertDontSee('</template>', false)
             ->assertDontSee('<p>Hello, World</p>', false)
-            ->assertSee('</turbo-stream>', false);
+            ->assertSee('</turbo-stream>', false)
+            ->assertDontSee('targets=');
+
+        $this->blade(<<<BLADE
+            <x-turbo-stream targets=".todos" action="append" >
+                <p>Hello, World</p>
+            </x-turbo-stream>
+            BLADE)
+            ->assertSee('<turbo-stream', false)
+            ->assertSee('targets=".todos"', false)
+            ->assertSee('action="append"', false)
+            ->assertSee('<template><p>Hello, World</p></template>', false)
+            ->assertSee('</turbo-stream>', false)
+            ->assertDontSee('target=');
     }
 
     /** @test */
@@ -112,5 +128,29 @@ class ComponentsTest extends TestCase
                 'model' => new TestModel(['id' => 123]),
             ])
             ->assertSee('<turbo-echo-stream-source channel="Tonysm.TurboLaravel.Tests.Stubs.Models.TestModel.123" type="public" ></turbo-echo-stream-source>', false);
+    }
+
+    /** @test */
+    public function stream_target_targets_should_throw_exception()
+    {
+        $this->expectException(ViewException::class);
+
+        $this->blade(<<<BLADE
+            <x-turbo-stream target="todo" targets=".todos" action="append" >
+                <p>Hello, World</p>
+            </x-turbo-stream>
+            BLADE);
+    }
+
+    /** @test */
+    public function stream_null_target_targets_should_throw_exception()
+    {
+        $this->expectException(ViewException::class);
+
+        $this->blade(<<<BLADE
+            <x-turbo-stream action="append" >
+                <p>Hello, World</p>
+            </x-turbo-stream>
+            BLADE);
     }
 }


### PR DESCRIPTION
This PR adds support to Turbo Streams Targeting Multiple Elements, by adding the option to the response macros and all underlying Blade components.

https://turbo.hotwired.dev/reference/streams#targeting-multiple-elements

We realize that this is an impactful PR, and we don't expect it to be merged without change or further discussion.
Please view this PR as the start of a conversation around the topic.

We have tried to balance staying compatible with the syntax from the Turbo handbook (so no separate `<turbo-stream>` component with `targets=` support) with not making any breaking changes to the API of this package, but we have had to make a few hard choices along the way. In particular, it was not possible to not make any breaking changes to the `Stream` component constructor without breaking compatibility with Turbo itself.