### PR TITLE
Tweaks targets

### DIFF
--- a/resources/views/components/stream.blade.php
+++ b/resources/views/components/stream.blade.php
@@ -1,4 +1,4 @@
-<turbo-stream @if(isset($targets))targets=@else{{''}}target=@endif"{{ $targetValue }}" action="{{ $action }}">
+<turbo-stream {{ $targetTag }}="{{ $targetValue }}" action="{{ $action }}">
 @if ($action !== "remove")
     <template>{{ $slot }}</template>
 @endif

--- a/src/Broadcasters/Broadcaster.php
+++ b/src/Broadcasters/Broadcaster.php
@@ -9,21 +9,21 @@ interface Broadcaster
     /**
      * @param Channel[] $channels
      * @param bool $later
-     * @param ?string $target
      * @param string $action
+     * @param ?string $target = null
+     * @param ?string $targets = null
      * @param ?string $partial = null
      * @param ?array $partialData = []
      * @param ?string $exceptSocket = null
-     * @param ?string $targets = null
      */
     public function broadcast(
         array $channels,
         bool $later,
-        ?string $target,
         string $action,
+        ?string $target = null,
+        ?string $targets = null,
         ?string $partial = null,
         ?array $partialData = [],
         ?string $exceptSocket = null,
-        ?string $targets = null
     ): void;
 }

--- a/src/Broadcasters/LaravelBroadcaster.php
+++ b/src/Broadcasters/LaravelBroadcaster.php
@@ -10,31 +10,31 @@ class LaravelBroadcaster implements Broadcaster
     /**
      * @param Channel[] $channels
      * @param bool $later
-     * @param ?string $target
      * @param string $action
+     * @param ?string $target = null
+     * @param ?string $targets = null
      * @param ?string $partial = null
      * @param ?array $partialData = []
      * @param ?string $exceptSocket = null
-     * @param ?string $targets = null
      */
     public function broadcast(
         array $channels,
         bool $later,
-        ?string $target,
         string $action,
+        ?string $target = null,
+        ?string $targets = null,
         ?string $partial = null,
         ?array $partialData = [],
         ?string $exceptSocket = null,
-        ?string $targets = null
     ): void {
         $job = new BroadcastAction(
             $channels,
-            $target,
             $action,
+            $target,
+            $targets,
             $partial,
             $partialData,
             $exceptSocket,
-            $targets
         );
 
         if ($later) {

--- a/src/Broadcasting/PendingBroadcast.php
+++ b/src/Broadcasting/PendingBroadcast.php
@@ -12,21 +12,21 @@ class PendingBroadcast
     /** @var Channel[] */
     public array $channels;
     public string $action;
-    public ?string $target;
+    public ?string $target = null;
+    public ?string $targets = null;
     public ?string $partialView = null;
     public ?array $partialData = [];
     public bool $sendToOthers = false;
     public bool $sendLater = false;
-    public ?string $targets = null;
 
-    public function __construct(array $channels, string $action, ?string $target, Rendering $rendering, ?string $targets = null)
+    public function __construct(array $channels, string $action, Rendering $rendering, ?string $target, ?string $targets = null)
     {
         $this->channels = $channels;
         $this->action = $action;
         $this->target = $target;
+        $this->targets = null;
         $this->partialView = $rendering->partial;
         $this->partialData = $rendering->data;
-        $this->targets = null;
     }
 
     public function to($channel): self
@@ -92,12 +92,12 @@ class PendingBroadcast
         $broadcaster->broadcast(
             $this->channels,
             $this->sendLater,
-            $this->target,
             $this->action,
+            $this->target,
+            $this->targets,
             $this->partialView,
             $this->partialData,
             $socket,
-            $this->targets
         );
     }
 }

--- a/src/Events/TurboStreamBroadcast.php
+++ b/src/Events/TurboStreamBroadcast.php
@@ -13,20 +13,20 @@ class TurboStreamBroadcast implements ShouldBroadcastNow
 
     /** @var Channel[] */
     public array $channels;
-    public ?string $target;
     public string $action;
+    public ?string $target = null;
+    public ?string $targets = null;
     public ?string $partial = null;
     public ?array $partialData = [];
-    public ?string $targets = null;
 
-    public function __construct(array $channels, ?string $target, string $action, ?string $partial = null, ?array $partialData = [], ?string $targets = null)
+    public function __construct(array $channels, string $action, ?string $target = null, ?string $targets = null, ?string $partial = null, ?array $partialData = [])
     {
         $this->channels = $channels;
-        $this->target = $target;
         $this->action = $action;
+        $this->target = $target;
+        $this->targets = $targets;
         $this->partial = $partial;
         $this->partialData = $partialData;
-        $this->targets = $targets;
     }
 
     public function broadcastOn()
@@ -44,11 +44,11 @@ class TurboStreamBroadcast implements ShouldBroadcastNow
     public function render(): string
     {
         return View::make('turbo-laravel::turbo-stream', [
-            'target' => $this->target,
             'action' => $this->action,
+            'target' => $this->target,
+            'targets' => $this->targets,
             'partial' => $this->partial ?: null,
             'partialData' => $this->partialData ?: [],
-            'targets' => $this->targets,
         ])->render();
     }
 }

--- a/src/Exceptions/TurboStreamTargetException.php
+++ b/src/Exceptions/TurboStreamTargetException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tonysm\TurboLaravel\Exceptions;
+
+use InvalidArgumentException;
+
+class TurboStreamTargetException extends InvalidArgumentException
+{
+    public static function targetMissing()
+    {
+        return new static('No target was specified');
+    }
+
+    public static function multipleTargets()
+    {
+        return new static('Must specify either target or targets attributes, but never both.');
+    }
+}

--- a/src/Http/PendingTurboStreamResponse.php
+++ b/src/Http/PendingTurboStreamResponse.php
@@ -10,7 +10,6 @@ use Tonysm\TurboLaravel\Broadcasting\Rendering;
 
 use function Tonysm\TurboLaravel\dom_id;
 use Tonysm\TurboLaravel\Models\Naming\Name;
-use Tonysm\TurboLaravel\NamesResolver;
 
 class PendingTurboStreamResponse implements Responsable
 {
@@ -295,15 +294,5 @@ class PendingTurboStreamResponse implements Responsable
     private function getResourceNameFor(Model $model): string
     {
         return Name::forModel($model)->plural;
-    }
-
-    private function getPartialViewFor(Model $model): string
-    {
-        return NamesResolver::partialNameFor($model);
-    }
-
-    private function getPartialDataFor(Model $model): array
-    {
-        return [NamesResolver::resourceVariableName($model) => $model];
     }
 }

--- a/src/Http/PendingTurboStreamResponse.php
+++ b/src/Http/PendingTurboStreamResponse.php
@@ -67,7 +67,6 @@ class PendingTurboStreamResponse implements Responsable
         return $this;
     }
 
-
     public function action(string $action): self
     {
         $this->useAction = $action;

--- a/src/Http/PendingTurboStreamResponse.php
+++ b/src/Http/PendingTurboStreamResponse.php
@@ -117,6 +117,15 @@ class PendingTurboStreamResponse implements Responsable
         );
     }
 
+    public function prependAll($targets, $content = null): self
+    {
+        return $this->buildActionAll(
+            action: 'prepend',
+            targets: $targets,
+            content: $content,
+        );
+    }
+
     public function before($target, $content = null): self
     {
         return $this->buildAction(

--- a/src/Http/PendingTurboStreamResponse.php
+++ b/src/Http/PendingTurboStreamResponse.php
@@ -135,11 +135,29 @@ class PendingTurboStreamResponse implements Responsable
         );
     }
 
+    public function beforeAll($targets, $content = null): self
+    {
+        return $this->buildActionAll(
+            action: 'before',
+            targets: $targets,
+            content: $content,
+        );
+    }
+
     public function after($target, $content = null): self
     {
         return $this->buildAction(
             action: 'after',
             target: $target instanceof Model ? $this->resolveTargetFor($target) : $target,
+            content: $content,
+        );
+    }
+
+    public function afterAll($targets, $content = null): self
+    {
+        return $this->buildActionAll(
+            action: 'after',
+            targets: $targets,
             content: $content,
         );
     }
@@ -163,23 +181,6 @@ class PendingTurboStreamResponse implements Responsable
         );
     }
 
-    public function replaceAll($targets, $content = null): self
-    {
-        return $this->buildActionAll(
-            action: 'replace',
-            targets: $targets,
-            content: $content,
-        );
-    }
-
-    public function removeAll($targets): self
-    {
-        return $this->buildActionAll(
-            action: 'remove',
-            targets: $targets,
-        );
-    }
-
     public function replace($target, $content = null): self
     {
         return $this->buildAction(
@@ -190,11 +191,28 @@ class PendingTurboStreamResponse implements Responsable
         );
     }
 
+    public function replaceAll($targets, $content = null): self
+    {
+        return $this->buildActionAll(
+            action: 'replace',
+            targets: $targets,
+            content: $content,
+        );
+    }
+
     public function remove($target): self
     {
         return $this->buildAction(
             action: 'remove',
             target: $target instanceof Model ? $this->resolveTargetFor($target) : $target,
+        );
+    }
+
+    public function removeAll($targets): self
+    {
+        return $this->buildActionAll(
+            action: 'remove',
+            targets: $targets,
         );
     }
 

--- a/src/Http/PendingTurboStreamResponse.php
+++ b/src/Http/PendingTurboStreamResponse.php
@@ -154,6 +154,23 @@ class PendingTurboStreamResponse implements Responsable
         );
     }
 
+    public function updateAll($targets, $content = null): self
+    {
+        return $this->buildActionAll(
+            action: 'update',
+            targets: $targets,
+            content: $content,
+        );
+    }
+    public function replaceAll($targets, $content = null): self
+    {
+        return $this->buildActionAll(
+            action: 'replace',
+            targets: $targets,
+            content: $content,
+        );
+    }
+
     public function replace($target, $content = null): self
     {
         return $this->buildAction(

--- a/src/Http/PendingTurboStreamResponse.php
+++ b/src/Http/PendingTurboStreamResponse.php
@@ -162,12 +162,21 @@ class PendingTurboStreamResponse implements Responsable
             content: $content,
         );
     }
+
     public function replaceAll($targets, $content = null): self
     {
         return $this->buildActionAll(
             action: 'replace',
             targets: $targets,
             content: $content,
+        );
+    }
+
+    public function removeAll($targets): self
+    {
+        return $this->buildActionAll(
+            action: 'remove',
+            targets: $targets,
         );
     }
 

--- a/src/Http/PendingTurboStreamResponse.php
+++ b/src/Http/PendingTurboStreamResponse.php
@@ -51,7 +51,7 @@ class PendingTurboStreamResponse implements Responsable
         );
     }
 
-    public function target($target, bool $resource = false): self
+    public function target(Model|string $target, bool $resource = false): self
     {
         $this->useTarget = $target instanceof Model ? $this->resolveTargetFor($target, $resource) : $target;
         $this->useTargets = null;
@@ -59,10 +59,10 @@ class PendingTurboStreamResponse implements Responsable
         return $this;
     }
 
-    public function targets($targets): self
+    public function targets(Model|string $targets): self
     {
         $this->useTarget = null;
-        $this->useTargets = $targets;
+        $this->useTargets = $targets instanceof Model ? $this->resolveTargetFor($targets, resource: true) : $targets;
 
         return $this;
     }
@@ -87,7 +87,7 @@ class PendingTurboStreamResponse implements Responsable
         return $this;
     }
 
-    public function append($target, $content = null): self
+    public function append(Model|string $target, $content = null): self
     {
         return $this->buildAction(
             action: 'append',
@@ -97,7 +97,7 @@ class PendingTurboStreamResponse implements Responsable
         );
     }
 
-    public function appendAll($targets, $content = null): self
+    public function appendAll(Model|string $targets, $content = null): self
     {
         return $this->buildActionAll(
             action: 'append',
@@ -106,7 +106,7 @@ class PendingTurboStreamResponse implements Responsable
         );
     }
 
-    public function prepend($target, $content = null): self
+    public function prepend(Model|string $target, $content = null): self
     {
         return $this->buildAction(
             action: 'prepend',
@@ -116,7 +116,7 @@ class PendingTurboStreamResponse implements Responsable
         );
     }
 
-    public function prependAll($targets, $content = null): self
+    public function prependAll(Model|string $targets, $content = null): self
     {
         return $this->buildActionAll(
             action: 'prepend',
@@ -125,16 +125,16 @@ class PendingTurboStreamResponse implements Responsable
         );
     }
 
-    public function before($target, $content = null): self
+    public function before(Model|string $target, $content = null): self
     {
         return $this->buildAction(
             action: 'before',
-            target: $target instanceof Model ? $this->resolveTargetFor($target) : $target,
+            target: $target,
             content: $content,
         );
     }
 
-    public function beforeAll($targets, $content = null): self
+    public function beforeAll(Model|string $targets, $content = null): self
     {
         return $this->buildActionAll(
             action: 'before',
@@ -143,16 +143,16 @@ class PendingTurboStreamResponse implements Responsable
         );
     }
 
-    public function after($target, $content = null): self
+    public function after(Model|string $target, $content = null): self
     {
         return $this->buildAction(
             action: 'after',
-            target: $target instanceof Model ? $this->resolveTargetFor($target) : $target,
+            target: $target,
             content: $content,
         );
     }
 
-    public function afterAll($targets, $content = null): self
+    public function afterAll(Model|string $targets, $content = null): self
     {
         return $this->buildActionAll(
             action: 'after',
@@ -161,17 +161,17 @@ class PendingTurboStreamResponse implements Responsable
         );
     }
 
-    public function update($target, $content = null): self
+    public function update(Model|string $target, $content = null): self
     {
         return $this->buildAction(
             action: 'update',
-            target: $target instanceof Model ? $this->resolveTargetFor($target) : $target,
+            target: $target,
             content: $content,
             rendering: $target instanceof Model ? Rendering::forModel($target) : null,
         );
     }
 
-    public function updateAll($targets, $content = null): self
+    public function updateAll(Model|string $targets, $content = null): self
     {
         return $this->buildActionAll(
             action: 'update',
@@ -180,17 +180,17 @@ class PendingTurboStreamResponse implements Responsable
         );
     }
 
-    public function replace($target, $content = null): self
+    public function replace(Model|string $target, $content = null): self
     {
         return $this->buildAction(
             action: 'replace',
-            target: $target instanceof Model ? $this->resolveTargetFor($target) : $target,
+            target: $target,
             content: $content,
             rendering: $target instanceof Model ? Rendering::forModel($target) : null,
         );
     }
 
-    public function replaceAll($targets, $content = null): self
+    public function replaceAll(Model|string $targets, $content = null): self
     {
         return $this->buildActionAll(
             action: 'replace',
@@ -199,15 +199,15 @@ class PendingTurboStreamResponse implements Responsable
         );
     }
 
-    public function remove($target): self
+    public function remove(Model|string $target): self
     {
         return $this->buildAction(
             action: 'remove',
-            target: $target instanceof Model ? $this->resolveTargetFor($target) : $target,
+            target: $target,
         );
     }
 
-    public function removeAll($targets): self
+    public function removeAll(Model|string $targets): self
     {
         return $this->buildActionAll(
             action: 'remove',
@@ -215,10 +215,10 @@ class PendingTurboStreamResponse implements Responsable
         );
     }
 
-    private function buildAction(string $action, $target, $content = null, ?Rendering $rendering = null)
+    private function buildAction(string $action, Model|string $target, $content = null, ?Rendering $rendering = null)
     {
         $this->useAction = $action;
-        $this->useTarget = $target;
+        $this->useTarget = $target instanceof Model ? $this->resolveTargetFor($target) : $target;
         $this->partialView = $rendering?->partial;
         $this->partialData = $rendering?->data ?? [];
         $this->inlineContent = $content;
@@ -226,11 +226,11 @@ class PendingTurboStreamResponse implements Responsable
         return $this;
     }
 
-    private function buildActionAll(string $action, $targets, $content = null)
+    private function buildActionAll(string $action, Model|string $targets, $content = null)
     {
         $this->useAction = $action;
         $this->useTarget = null;
-        $this->useTargets = $targets;
+        $this->useTargets = $targets instanceof Model ? $this->resolveTargetFor($targets, resource: true) : $targets;
         $this->inlineContent = $content;
 
         return $this;

--- a/src/Http/PendingTurboStreamResponse.php
+++ b/src/Http/PendingTurboStreamResponse.php
@@ -98,6 +98,15 @@ class PendingTurboStreamResponse implements Responsable
         );
     }
 
+    public function appendAll($targets, $content = null): self
+    {
+        return $this->buildActionAll(
+            action: 'append',
+            targets: $targets,
+            content: $content,
+        );
+    }
+
     public function prepend($target, $content = null): self
     {
         return $this->buildAction(
@@ -160,6 +169,16 @@ class PendingTurboStreamResponse implements Responsable
         $this->useTarget = $target;
         $this->partialView = $rendering?->partial;
         $this->partialData = $rendering?->data ?? [];
+        $this->inlineContent = $content;
+
+        return $this;
+    }
+
+    private function buildActionAll(string $action, $targets, $content = null)
+    {
+        $this->useAction = $action;
+        $this->useTarget = null;
+        $this->useTargets = $targets;
         $this->inlineContent = $content;
 
         return $this;

--- a/src/Jobs/BroadcastAction.php
+++ b/src/Jobs/BroadcastAction.php
@@ -13,22 +13,22 @@ class BroadcastAction implements ShouldQueue
     use SerializesModels;
 
     public array $channels;
-    public ?string $target;
     public string $action;
+    public ?string $target;
+    public ?string $targets;
     public ?string $partial;
     public ?array $partialData;
     public ?string $socket;
-    public ?string $targets;
 
-    public function __construct(array $channels, ?string $target, string $action, ?string $partial = null, ?array $partialData = [], $socket = null, $targets = null)
+    public function __construct(array $channels, string $action, ?string $target = null, ?string $targets = null, ?string $partial = null, ?array $partialData = [], $socket = null)
     {
         $this->channels = $channels;
-        $this->target = $target;
         $this->action = $action;
+        $this->target = $target;
+        $this->targets = $targets;
         $this->partial = $partial;
         $this->partialData = $partialData;
         $this->socket = $socket;
-        $this->targets = $targets;
     }
 
     public function handle()
@@ -40,11 +40,11 @@ class BroadcastAction implements ShouldQueue
     {
         $event = new TurboStreamBroadcast(
             $this->channels,
-            $this->target,
             $this->action,
+            $this->target,
+            $this->targets,
             $this->partial,
             $this->partialData,
-            $this->targets
         );
 
         $event->socket = $this->socket;

--- a/src/Models/Broadcasts.php
+++ b/src/Models/Broadcasts.php
@@ -125,8 +125,8 @@ trait Broadcasts
         return new PendingBroadcast(
             $this->toChannels(Collection::wrap($streamables)),
             $action,
-            $target ?: $this->broadcastDefaultTarget($action),
             $rendering,
+            $target ?: $this->broadcastDefaultTarget($action),
         );
     }
 

--- a/src/Testing/AssertableTurboStream.php
+++ b/src/Testing/AssertableTurboStream.php
@@ -25,12 +25,15 @@ class AssertableTurboStream
 
     public function hasTurboStream(Closure $callback = null): self
     {
+        $callback ??= fn ($matcher) => $matcher;
         $attrs = collect();
 
         $matches = $this->turboStreams
             ->mapInto(TurboStreamMatcher::class)
-            ->filter(function ($matcher) use ($callback, $attrs) {
-                if (! $matcher->matches($callback)) {
+            ->filter(function (TurboStreamMatcher $matcher) use ($callback, $attrs) {
+                $matcher = $callback($matcher);
+
+                if (! $matcher->matches()) {
                     $attrs->add($matcher->attrs());
 
                     return false;

--- a/src/Testing/TurboStreamMatcher.php
+++ b/src/Testing/TurboStreamMatcher.php
@@ -52,7 +52,7 @@ class TurboStreamMatcher
         // and `->see()` methods will be called by the developers.
 
         if ($callback) {
-            return $callback($this);
+            return $callback($this)->matches();
         }
 
         // After registering the desired attributes and contents the developers want

--- a/src/Testing/TurboStreamMatcher.php
+++ b/src/Testing/TurboStreamMatcher.php
@@ -21,24 +21,28 @@ class TurboStreamMatcher
 
     public function where(string $prop, string $value): self
     {
+        $matcher = clone $this;
+
         // We're storing the props locally because we need to
         // wait for the `->matches()` call to check if this
         // Turbo Stream has all the attributes at once.
 
-        $this->wheres[$prop] = $value;
+        $matcher->wheres[$prop] = $value;
 
-        return $this;
+        return $matcher;
     }
 
     public function see(string $content): self
     {
+        $matcher = clone $this;
+
         // Similarly to how we do with the attributes, the contents
         // of the Turbo Stream tag the user wants to assert will
         // be store for latter, after the `->matches()` call.
 
-        $this->contents[] = $content;
+        $matcher->contents[] = $content;
 
-        return $this;
+        return $matcher;
     }
 
     public function matches(Closure $callback = null): bool

--- a/src/Testing/TurboStreamMatcher.php
+++ b/src/Testing/TurboStreamMatcher.php
@@ -52,7 +52,7 @@ class TurboStreamMatcher
         // and `->see()` methods will be called by the developers.
 
         if ($callback) {
-            $callback($this);
+            return $callback($this);
         }
 
         // After registering the desired attributes and contents the developers want

--- a/src/Views/Components/Stream.php
+++ b/src/Views/Components/Stream.php
@@ -9,34 +9,31 @@ use function Tonysm\TurboLaravel\dom_id;
 
 class Stream extends Component
 {
-    public string|Model|array|null $target;
+    public string|Model|array|null $target = null;
+    public string|null $targets = null;
 
     public ?string $action;
-
-    public ?string $targets;
 
     /**
      * Create a new component instance.
      *
-     * @param string|Model|array|null $target The DOM ID string, a model to generate the DOM ID for, or an array to be passed to the `dom_id` function.
      * @param ?string $action One of the seven Turbo Stream actions: "append", "prepend", "before", "after", "replace", "update", or "remove".
+     * @param string|Model|array|null $target The DOM ID string, a model to generate the DOM ID for, or an array to be passed to the `dom_id` function.
      * @param string|null $targets The CSS selector to apply the action to multiple targets
      */
-    public function __construct(string|Model|array|null $target = null, ?string $action = null, ?string $targets = null)
+    public function __construct(string $action, string|Model|array|null $target = null, string|null $targets = null)
     {
-        $this->target = $target;
-        $this->action = $action;
-        $this->targets = $targets;
-        if (!$action) {
-            throw new \InvalidArgumentException('Action is required');
-        }
-        if (!$target && !$targets) {
-            throw new \InvalidArgumentException('targets and target cannot be both null');
+        if (! $target && ! $targets) {
+            throw new \InvalidArgumentException('No target was specified');
         }
 
         if ($target && $targets) {
-            throw new \InvalidArgumentException('targets and target are both set. One needs to be null');
+            throw new \InvalidArgumentException('Must specify either target or targets attributes, but never both.');
         }
+
+        $this->target = $target;
+        $this->targets = $targets;
+        $this->action = $action;
     }
 
     /**
@@ -48,12 +45,13 @@ class Stream extends Component
     {
         return view('turbo-laravel::components.stream', [
             'targetValue' => $this->targetValue(),
+            'targetTag' => ($this->targets ?? false) ? 'targets' : 'target',
         ]);
     }
 
     private function targetValue(): string
     {
-        if (isset($this->targets)){
+        if ($this->targets ?? false) {
             return $this->targets;
         }
 

--- a/src/Views/Components/Stream.php
+++ b/src/Views/Components/Stream.php
@@ -4,9 +4,9 @@ namespace Tonysm\TurboLaravel\Views\Components;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\View\Component;
-use Tonysm\TurboLaravel\Exceptions\TurboStreamTargetException;
-
 use function Tonysm\TurboLaravel\dom_id;
+
+use Tonysm\TurboLaravel\Exceptions\TurboStreamTargetException;
 
 class Stream extends Component
 {

--- a/src/Views/Components/Stream.php
+++ b/src/Views/Components/Stream.php
@@ -4,6 +4,7 @@ namespace Tonysm\TurboLaravel\Views\Components;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\View\Component;
+use Tonysm\TurboLaravel\Exceptions\TurboStreamTargetException;
 
 use function Tonysm\TurboLaravel\dom_id;
 
@@ -24,11 +25,11 @@ class Stream extends Component
     public function __construct(string $action, string|Model|array|null $target = null, string|null $targets = null)
     {
         if (! $target && ! $targets) {
-            throw new \InvalidArgumentException('No target was specified');
+            throw TurboStreamTargetException::targetMissing();
         }
 
         if ($target && $targets) {
-            throw new \InvalidArgumentException('Must specify either target or targets attributes, but never both.');
+            throw TurboStreamTargetException::multipleTargets();
         }
 
         $this->target = $target;

--- a/tests/Events/TurboStreamBroadcastTest.php
+++ b/tests/Events/TurboStreamBroadcastTest.php
@@ -21,8 +21,9 @@ class TurboStreamBroadcastTest extends TestCase
     {
         $event = new TurboStreamBroadcast(
             [],
-            'test_target',
             'replace',
+            'test_target',
+            null,
             'test_models._test_model',
             ['testModel' => new TestModel(['id' => 1])]
         );
@@ -46,16 +47,16 @@ class TurboStreamBroadcastTest extends TestCase
     {
         $event = new TurboStreamBroadcast(
             [],
-            null,
             'replace',
+            null,
+            '.targets',
             'test_models._test_model',
             ['testModel' => new TestModel(['id' => 1])],
-            'targets'
         );
 
         $expected = View::make('turbo-laravel::turbo-stream', [
-            'targets' => 'targets',
             'action' => 'replace',
+            'targets' => '.targets',
             'partial' => 'test_models._test_model',
             'partialData' => [
                 'testModel' => new TestModel(['id' => 1]),

--- a/tests/Http/ResponseMacrosTest.php
+++ b/tests/Http/ResponseMacrosTest.php
@@ -427,6 +427,61 @@ class ResponseMacrosTest extends TestCase
         $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
     }
 
+
+    /** @test */
+    public function prepend_all_with_inline_content_string()
+    {
+        $response = response()
+            ->turboStream()
+            ->prependAll('.test_models', 'Some inline content')
+            ->toResponse(new Request);
+
+        $expected = view('turbo-laravel::turbo-stream', [
+            'action' => 'prepend',
+            'targets' => '.test_models',
+            'content' => 'Some inline content',
+        ])->render();
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
+    public function prepend_all_passing_html_safe_string()
+    {
+        $response = response()
+            ->turboStream()
+            ->prependAll('.test_models', new HtmlString('<div>Some safe HTML content</div>'))
+            ->toResponse(new Request);
+
+        $expected = <<<HTML
+        <turbo-stream targets=".test_models" action="prepend">
+            <template><div>Some safe HTML content</div></template>
+        </turbo-stream>
+        HTML;
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
+    public function prepend_all_passing_view_as_content()
+    {
+        $response = response()
+            ->turboStream()
+            ->prependAll('.test_models', view('hello_view', ['name' => 'Tester']))
+            ->toResponse(new Request);
+
+        $expected = <<<HTML
+        <turbo-stream targets=".test_models" action="prepend">
+            <template><div>Hello, Tester</div></template>
+        </turbo-stream>
+        HTML;
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
     /** @test */
     public function update_shorthand_for_response_builder()
     {

--- a/tests/Http/ResponseMacrosTest.php
+++ b/tests/Http/ResponseMacrosTest.php
@@ -715,6 +715,23 @@ class ResponseMacrosTest extends TestCase
     }
 
     /** @test */
+    public function remove_all()
+    {
+        $response = response()
+            ->turboStream()
+            ->removeAll('.test_models')
+            ->toResponse(new Request);
+
+        $expected = view('turbo-laravel::turbo-stream', [
+            'action' => 'remove',
+            'targets' => '.test_models',
+        ])->render();
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
     public function before_shorthand()
     {
         $response = response()

--- a/tests/Http/ResponseMacrosTest.php
+++ b/tests/Http/ResponseMacrosTest.php
@@ -788,6 +788,60 @@ class ResponseMacrosTest extends TestCase
     }
 
     /** @test */
+    public function before_all_with_inline_content_string()
+    {
+        $response = response()
+            ->turboStream()
+            ->beforeAll('.test_models', 'Some inline content')
+            ->toResponse(new Request);
+
+        $expected = view('turbo-laravel::turbo-stream', [
+            'action' => 'before',
+            'targets' => '.test_models',
+            'content' => 'Some inline content',
+        ])->render();
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
+    public function before_all_passing_html_safe_string()
+    {
+        $response = response()
+            ->turboStream()
+            ->beforeAll('.test_models', new HtmlString('<div>Some safe HTML content</div>'))
+            ->toResponse(new Request);
+
+        $expected = <<<HTML
+        <turbo-stream targets=".test_models" action="before">
+            <template><div>Some safe HTML content</div></template>
+        </turbo-stream>
+        HTML;
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
+    public function before_all_passing_view_as_content()
+    {
+        $response = response()
+            ->turboStream()
+            ->beforeAll('.test_models', view('hello_view', ['name' => 'Tester']))
+            ->toResponse(new Request);
+
+        $expected = <<<HTML
+        <turbo-stream targets=".test_models" action="before">
+            <template><div>Hello, Tester</div></template>
+        </turbo-stream>
+        HTML;
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
     public function after_shorthand()
     {
         $response = response()
@@ -820,6 +874,60 @@ class ResponseMacrosTest extends TestCase
             'target' => 'some_dom_id',
             'content' => 'Hello World',
         ])->render();
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
+    public function after_all_with_inline_content_string()
+    {
+        $response = response()
+            ->turboStream()
+            ->afterAll('.test_models', 'Some inline content')
+            ->toResponse(new Request);
+
+        $expected = view('turbo-laravel::turbo-stream', [
+            'action' => 'after',
+            'targets' => '.test_models',
+            'content' => 'Some inline content',
+        ])->render();
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
+    public function after_all_passing_html_safe_string()
+    {
+        $response = response()
+            ->turboStream()
+            ->afterAll('.test_models', new HtmlString('<div>Some safe HTML content</div>'))
+            ->toResponse(new Request);
+
+        $expected = <<<HTML
+        <turbo-stream targets=".test_models" action="after">
+            <template><div>Some safe HTML content</div></template>
+        </turbo-stream>
+        HTML;
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
+    public function after_all_passing_view_as_content()
+    {
+        $response = response()
+            ->turboStream()
+            ->afterAll('.test_models', view('hello_view', ['name' => 'Tester']))
+            ->toResponse(new Request);
+
+        $expected = <<<HTML
+        <turbo-stream targets=".test_models" action="after">
+            <template><div>Hello, Tester</div></template>
+        </turbo-stream>
+        HTML;
 
         $this->assertEquals(trim($expected), trim($response->getContent()));
         $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));

--- a/tests/Http/ResponseMacrosTest.php
+++ b/tests/Http/ResponseMacrosTest.php
@@ -597,13 +597,13 @@ class ResponseMacrosTest extends TestCase
     {
         $response = response()
             ->turboStream()
-            ->targets('test_targets')
-            ->remove('test_models_target')
+            ->action('remove')
+            ->targets('.some_dom_class')
             ->toResponse(new Request);
 
         $expected = view('turbo-laravel::turbo-stream', [
             'action' => 'remove',
-            'targets' => 'test_targets',
+            'targets' => '.some_dom_class',
         ])->render();
 
         $this->assertEquals(trim($expected), trim($response->getContent()));

--- a/tests/Http/ResponseMacrosTest.php
+++ b/tests/Http/ResponseMacrosTest.php
@@ -337,6 +337,60 @@ class ResponseMacrosTest extends TestCase
     }
 
     /** @test */
+    public function append_all_with_inline_content_string()
+    {
+        $response = response()
+            ->turboStream()
+            ->appendAll('.test_models', 'Some inline content')
+            ->toResponse(new Request);
+
+        $expected = view('turbo-laravel::turbo-stream', [
+            'action' => 'append',
+            'targets' => '.test_models',
+            'content' => 'Some inline content',
+        ])->render();
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
+    public function append_all_passing_html_safe_string()
+    {
+        $response = response()
+            ->turboStream()
+            ->appendAll('.test_models', new HtmlString('<div>Some safe HTML content</div>'))
+            ->toResponse(new Request);
+
+        $expected = <<<HTML
+        <turbo-stream targets=".test_models" action="append">
+            <template><div>Some safe HTML content</div></template>
+        </turbo-stream>
+        HTML;
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
+    public function append_all_passing_view_as_content()
+    {
+        $response = response()
+            ->turboStream()
+            ->appendAll('.test_models', view('hello_view', ['name' => 'Tester']))
+            ->toResponse(new Request);
+
+        $expected = <<<HTML
+        <turbo-stream targets=".test_models" action="append">
+            <template><div>Hello, Tester</div></template>
+        </turbo-stream>
+        HTML;
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
     public function prepend_shorthand_for_response_builder()
     {
         $response = response()

--- a/tests/Http/ResponseMacrosTest.php
+++ b/tests/Http/ResponseMacrosTest.php
@@ -427,7 +427,6 @@ class ResponseMacrosTest extends TestCase
         $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
     }
 
-
     /** @test */
     public function prepend_all_with_inline_content_string()
     {
@@ -520,6 +519,60 @@ class ResponseMacrosTest extends TestCase
     }
 
     /** @test */
+    public function update_all_with_inline_content_string()
+    {
+        $response = response()
+            ->turboStream()
+            ->updateAll('.test_models', 'Some inline content')
+            ->toResponse(new Request);
+
+        $expected = view('turbo-laravel::turbo-stream', [
+            'action' => 'update',
+            'targets' => '.test_models',
+            'content' => 'Some inline content',
+        ])->render();
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
+    public function update_all_passing_html_safe_string()
+    {
+        $response = response()
+            ->turboStream()
+            ->updateAll('.test_models', new HtmlString('<div>Some safe HTML content</div>'))
+            ->toResponse(new Request);
+
+        $expected = <<<HTML
+        <turbo-stream targets=".test_models" action="update">
+            <template><div>Some safe HTML content</div></template>
+        </turbo-stream>
+        HTML;
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
+    public function update_all_passing_view_as_content()
+    {
+        $response = response()
+            ->turboStream()
+            ->updateAll('.test_models', view('hello_view', ['name' => 'Tester']))
+            ->toResponse(new Request);
+
+        $expected = <<<HTML
+        <turbo-stream targets=".test_models" action="update">
+            <template><div>Hello, Tester</div></template>
+        </turbo-stream>
+        HTML;
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
     public function replace_shorthand_for_response_builder()
     {
         $response = response()
@@ -551,6 +604,60 @@ class ResponseMacrosTest extends TestCase
             'target' => 'test_models_target',
             'content' => 'Hello World',
         ])->render();
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
+    public function replace_all_with_inline_content_string()
+    {
+        $response = response()
+            ->turboStream()
+            ->replaceAll('.test_models', 'Some inline content')
+            ->toResponse(new Request);
+
+        $expected = view('turbo-laravel::turbo-stream', [
+            'action' => 'replace',
+            'targets' => '.test_models',
+            'content' => 'Some inline content',
+        ])->render();
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
+    public function replace_all_passing_html_safe_string()
+    {
+        $response = response()
+            ->turboStream()
+            ->replaceAll('.test_models', new HtmlString('<div>Some safe HTML content</div>'))
+            ->toResponse(new Request);
+
+        $expected = <<<HTML
+        <turbo-stream targets=".test_models" action="replace">
+            <template><div>Some safe HTML content</div></template>
+        </turbo-stream>
+        HTML;
+
+        $this->assertEquals(trim($expected), trim($response->getContent()));
+        $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));
+    }
+
+    /** @test */
+    public function replace_all_passing_view_as_content()
+    {
+        $response = response()
+            ->turboStream()
+            ->replaceAll('.test_models', view('hello_view', ['name' => 'Tester']))
+            ->toResponse(new Request);
+
+        $expected = <<<HTML
+        <turbo-stream targets=".test_models" action="replace">
+            <template><div>Hello, Tester</div></template>
+        </turbo-stream>
+        HTML;
 
         $this->assertEquals(trim($expected), trim($response->getContent()));
         $this->assertEquals(Turbo::TURBO_STREAM_FORMAT, $response->headers->get('Content-Type'));

--- a/tests/Http/TurboStreamResponseTest.php
+++ b/tests/Http/TurboStreamResponseTest.php
@@ -76,8 +76,8 @@ class TurboStreamResponseTest extends TestCase
                                 ->where('action', 'remove')
                 ))
                 && $turboStreams->hasTurboStream(fn ($turboStream) => (
-                $turboStream->where('targets', '.post')
-                    ->where('action', 'replace')
+                    $turboStream->where('targets', '.post')
+                                ->where('action', 'replace')
                 ))
             ));
     }

--- a/tests/Models/BroadcastsModelTest.php
+++ b/tests/Models/BroadcastsModelTest.php
@@ -396,7 +396,7 @@ class BroadcastsModelTest extends TestCase
         Bus::assertNotDispatched(BroadcastAction::class);
 
         $model->broadcastAppend()
-            ->targets('test_targets');
+            ->targets('.test_targets');
 
         Bus::assertDispatched(function (BroadcastAction $job) use ($model) {
             $this->assertCount(1, $job->channels);
@@ -405,7 +405,7 @@ class BroadcastsModelTest extends TestCase
             $this->assertEquals('append', $job->action);
             $this->assertEquals('broadcast_test_models._broadcast_test_model', $job->partial);
             $this->assertEquals(['broadcastTestModel' => $model], $job->partialData);
-            $this->assertEquals('test_targets', $job->targets);
+            $this->assertEquals('.test_targets', $job->targets);
 
             return true;
         });

--- a/tests/Testing/TurboStreamMatcherTest.php
+++ b/tests/Testing/TurboStreamMatcherTest.php
@@ -14,7 +14,7 @@ class TurboStreamMatcherTest extends TestCase
     {
         parent::setUp();
 
-        $this->response = new TestResponse(response(<<<html
+        $this->response = new TestResponse(response(<<<HTML
         <turbo-stream action="append" target="item_1">
             <template>
                 <h1>First Item</h1>
@@ -35,7 +35,7 @@ class TurboStreamMatcherTest extends TestCase
                 <h1>new Item</h1>
             </template>
         </turbo-stream>
-        html));
+        HTML));
 
         $this->streams = (new ConvertTestResponseToTurboStreamCollection)($this->response)->mapInto(TurboStreamMatcher::class);
     }
@@ -49,30 +49,34 @@ class TurboStreamMatcherTest extends TestCase
     /** @test */
     public function filters_by_attributes()
     {
+        // Matches on action...
         $appends = $this->streams->filter(fn (TurboStreamMatcher $matcher) => (
-            (clone $matcher)->where('action', 'append')->matches()
+            $matcher->where('action', 'append')->matches()
         ));
 
         $this->assertCount(2, $appends);
 
+        // Matches on target...
         $appends = $appends->filter(fn (TurboStreamMatcher $matcher) => (
-            (clone $matcher)->where('target', 'item_2')->matches()
+            $matcher->where('target', 'item_2')->matches()
         ));
 
         $this->assertCount(1, $appends);
 
-        // Both action and target attributes.
+        // Matches both on action and target...
         $remove_item_3 = $this->streams->filter(fn (TurboStreamMatcher $matcher) => (
-            (clone $matcher)->where('action', 'remove')
+            $matcher->where('action', 'remove')
                 ->where('target', 'item_3')
                 ->matches()
         ));
 
         $this->assertCount(1, $remove_item_3);
 
+        // Matches on targets attribute...
         $targets = $this->streams->filter(fn (TurboStreamMatcher $matcher) => (
-            (clone $matcher)->where('targets', '.items')->matches()
+            $matcher->where('targets', '.items')->matches()
         ));
+
         $this->assertCount(1, $targets);
     }
 

--- a/tests/Views/ComponentsTest.php
+++ b/tests/Views/ComponentsTest.php
@@ -136,10 +136,10 @@ class ComponentsTest extends TestCase
         $this->expectException(ViewException::class);
 
         $this->blade(<<<BLADE
-            <x-turbo-stream target="todo" targets=".todos" action="append" >
-                <p>Hello, World</p>
-            </x-turbo-stream>
-            BLADE);
+        <x-turbo-stream target="todo" targets=".todos" action="append" >
+            <p>Hello, World</p>
+        </x-turbo-stream>
+        BLADE);
     }
 
     /** @test */
@@ -148,9 +148,9 @@ class ComponentsTest extends TestCase
         $this->expectException(ViewException::class);
 
         $this->blade(<<<BLADE
-            <x-turbo-stream action="append" >
-                <p>Hello, World</p>
-            </x-turbo-stream>
-            BLADE);
+        <x-turbo-stream action="append" >
+            <p>Hello, World</p>
+        </x-turbo-stream>
+        BLADE);
     }
 }


### PR DESCRIPTION
### Added

- Adds new `appendAll`, `prependAll`, `beforeAll`, `afterAll`, `updateAll`, `replaceAll`, and `removeAll` methods

### Changed

- **BC** The `Broadcaster` interface and concrete implementation API changed
- **BC** The `PendingBroadcast` parameter order changed 
- **BC**: The `TurboStreamBroadcast` parameter order changed
- The `TurboStreamMatcher` is now cloned whenever the `where()` or `see()` methods are called to avoid some left-overs

---

This is a follow-up PR on the work done in https://github.com/tonysm/turbo-laravel/pull/86