### PR TITLE
Fix the turbo-echo-stream-source custom tag was not connecting to public channel

### DIFF
--- a/stubs/resources/js/elements/turbo-echo-stream-tag.js
+++ b/stubs/resources/js/elements/turbo-echo-stream-tag.js
@@ -5,7 +5,11 @@ const subscribeTo = (type, channel) => {
         return window.Echo.join(channel)
     }
 
-    return window.Echo[type](channel)
+    if (type === 'private') {
+        return window.Echo.private(channel)
+    }
+
+    return window.Echo.channel(channel)
 }
 
 class TurboEchoStreamSourceElement extends HTMLElement {


### PR DESCRIPTION
### Fixed

- Fixes the `turbo-echo-stream-source` custom HTML tag not being able to connect to public channels