### PR TITLE
Adds the plural version of wantsTurboStream() macro for convenience

### DIFF
--- a/src/TurboServiceProvider.php
+++ b/src/TurboServiceProvider.php
@@ -123,6 +123,10 @@ class TurboServiceProvider extends ServiceProvider
             return Str::contains($this->header('Accept'), Turbo::TURBO_STREAM_FORMAT);
         });
 
+        Request::macro('wantsTurboStreams', function (): bool {
+            return $this->wantsTurboStream();
+        });
+
         Request::macro('wasFromTurboNative', function (): bool {
             return TurboFacade::isTurboNativeVisit();
         });

--- a/tests/Http/RequestMacrosTest.php
+++ b/tests/Http/RequestMacrosTest.php
@@ -14,12 +14,14 @@ class RequestMacrosTest extends TestCase
     {
         $request = Request::create('/hello');
         $this->assertFalse($request->wantsTurboStream(), 'Expected request to not want a turbo stream response, but it did.');
+        $this->assertFalse($request->wantsTurboStreams(), 'Expected request to not want a turbo stream response, but it did.');
 
         $request = Request::create('/hello');
         $request->headers->add([
             'Accept' => Turbo::TURBO_STREAM_FORMAT.', text/html, application/xhtml+xml',
         ]);
         $this->assertTrue($request->wantsTurboStream(), 'Expected request to want a turbo stream response, but it did not.');
+        $this->assertTrue($request->wantsTurboStreams(), 'Expected request to want a turbo stream response, but it did not.');
     }
 
     /** @test */


### PR DESCRIPTION
### Added

- Adds a `request()->wantsTurboStreams()` (plural) macro for convenience which is an alias for `request()->wantsTurboStream()`

---

closes https://github.com/hotwired-laravel/turbo-laravel/issues/122