### PR TITLE
Send flash messages via query string on Turbo Native redirects (recede, resume, & refresh)

### DIFF
--- a/src/Http/Controllers/Concerns/InteractsWithTurboNativeNavigation.php
+++ b/src/Http/Controllers/Concerns/InteractsWithTurboNativeNavigation.php
@@ -2,6 +2,8 @@
 
 namespace HotwiredLaravel\TurboLaravel\Http\Controllers\Concerns;
 
+use HotwiredLaravel\TurboLaravel\Http\TurboNativeRedirectResponse;
+
 trait InteractsWithTurboNativeNavigation
 {
     protected function recedeOrRedirectTo(string $url)
@@ -37,7 +39,7 @@ trait InteractsWithTurboNativeNavigation
     protected function redirectToTurboNativeAction(string $action, string $fallbackUrl, string $redirectType = 'to', array $options = [])
     {
         if (request()->wasFromTurboNative()) {
-            return redirect(route("turbo_{$action}_historical_location"));
+            return new TurboNativeRedirectResponse(route("turbo_{$action}_historical_location"));
         }
 
         if ($redirectType === 'back') {

--- a/src/Http/Controllers/Concerns/InteractsWithTurboNativeNavigation.php
+++ b/src/Http/Controllers/Concerns/InteractsWithTurboNativeNavigation.php
@@ -39,7 +39,7 @@ trait InteractsWithTurboNativeNavigation
     protected function redirectToTurboNativeAction(string $action, string $fallbackUrl, string $redirectType = 'to', array $options = [])
     {
         if (request()->wasFromTurboNative()) {
-            return new TurboNativeRedirectResponse(route("turbo_{$action}_historical_location"));
+            return TurboNativeRedirectResponse::createFromFallbackUrl($action, $fallbackUrl);
         }
 
         if ($redirectType === 'back') {

--- a/src/Http/TurboNativeRedirectResponse.php
+++ b/src/Http/TurboNativeRedirectResponse.php
@@ -7,12 +7,23 @@ use Illuminate\Support\Str;
 
 class TurboNativeRedirectResponse extends RedirectResponse
 {
-    public static function createFromFallbackUrl(string $action, string $fallbackUrl)
+    /**
+     * Factory method that builds a new instance of the TurboNativeRedirectResponse
+     * and extracts the query strings from the given action and fallback URL.
+     */
+    public static function createFromFallbackUrl(string $action, string $fallbackUrl): self
     {
         return (new self(route("turbo_{$action}_historical_location")))
             ->withQueryString((new self($fallbackUrl))->getQueryString());
     }
 
+    /**
+     * Sets the flashed data via query strings when redirecting to Turbo Native routes.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return self
+     */
     public function with($key, $value = null)
     {
         $params = $this->getQueryString();
@@ -21,6 +32,9 @@ class TurboNativeRedirectResponse extends RedirectResponse
             ->setTargetUrl($this->getTargetUrl().'?'.http_build_query($params + [$key => urlencode($value)]));
     }
 
+    /**
+     * Sets multiple query strings at the same time.
+     */
     protected function withQueryString(array $params): self
     {
         foreach ($params as $key => $val) {
@@ -30,6 +44,9 @@ class TurboNativeRedirectResponse extends RedirectResponse
         return $this;
     }
 
+    /**
+     * Returns the query string as an array.
+     */
     protected function getQueryString(): array
     {
         parse_str(str_contains($this->getTargetUrl(), '?') ? Str::after($this->getTargetUrl(), '?') : '', $query);
@@ -37,6 +54,9 @@ class TurboNativeRedirectResponse extends RedirectResponse
         return $query;
     }
 
+    /**
+     * Returns the target URL without the query strings.
+     */
     protected function withoutQueryStrings(): self
     {
         $fragment = str_contains($this->getTargetUrl(), '#') ? Str::after($this->getTargetUrl(), '#') : '';

--- a/src/Http/TurboNativeRedirectResponse.php
+++ b/src/Http/TurboNativeRedirectResponse.php
@@ -7,12 +7,27 @@ use Illuminate\Support\Str;
 
 class TurboNativeRedirectResponse extends RedirectResponse
 {
+    public static function createFromFallbackUrl(string $action, string $fallbackUrl)
+    {
+        return (new self(route("turbo_{$action}_historical_location")))
+            ->withQueryString((new self($fallbackUrl))->getQueryString());
+    }
+
     public function with($key, $value = null)
     {
         $params = $this->getQueryString();
 
         return $this->withoutQueryStrings()
             ->setTargetUrl($this->getTargetUrl().'?'.http_build_query($params + [$key => urlencode($value)]));
+    }
+
+    protected function withQueryString(array $params): self
+    {
+        foreach ($params as $key => $val) {
+            $this->with($key, $val);
+        }
+
+        return $this;
     }
 
     protected function getQueryString(): array

--- a/src/Http/TurboNativeRedirectResponse.php
+++ b/src/Http/TurboNativeRedirectResponse.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace HotwiredLaravel\TurboLaravel\Http;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Str;
+
+class TurboNativeRedirectResponse extends RedirectResponse
+{
+    public function with($key, $value = null)
+    {
+        $params = $this->getQueryString();
+
+        return $this->withoutQueryStrings()
+            ->setTargetUrl($this->getTargetUrl().'?'.http_build_query($params + [$key => urlencode($value)]));
+    }
+
+    protected function getQueryString(): array
+    {
+        parse_str(str_contains($this->getTargetUrl(), '?') ? Str::after($this->getTargetUrl(), '?') : '', $query);
+
+        return $query;
+    }
+
+    protected function withoutQueryStrings(): self
+    {
+        $fragment = str_contains($this->getTargetUrl(), '#') ? Str::after($this->getTargetUrl(), '#') : '';
+
+        return $this->withoutFragment()
+            ->setTargetUrl(Str::before($this->getTargetUrl(), '?').($fragment ? "#{$fragment}" : ''));
+    }
+}

--- a/src/Http/TurboNativeRedirectResponse.php
+++ b/src/Http/TurboNativeRedirectResponse.php
@@ -8,8 +8,9 @@ use Illuminate\Support\Str;
 class TurboNativeRedirectResponse extends RedirectResponse
 {
     /**
-     * Factory method that builds a new instance of the TurboNativeRedirectResponse
-     * and extracts the query strings from the given action and fallback URL.
+     * Factory Method that builds a new instance of the TurboNativeRedirectResponse
+     * with the given action and forwards the query strings from the given fallback
+     * URL to the Turbo Native redirect ones.
      */
     public static function createFromFallbackUrl(string $action, string $fallbackUrl): self
     {

--- a/tests/Http/TurboNativeNavigationControllerTest.php
+++ b/tests/Http/TurboNativeNavigationControllerTest.php
@@ -60,7 +60,6 @@ class TurboNativeNavigationControllerTest extends TestCase
             ->post(route('trays.store'), ['return_to' => "{$action}_or_redirect", 'with' => true, 'fragment' => true])
             ->assertRedirect(route("turbo_{$action}_historical_location", ['status' => urlencode(__('Tray created.'))]).'#newly-created-tray')
             ->assertSessionMissing('status');
-
     }
 
     /**

--- a/tests/Http/TurboNativeNavigationControllerTest.php
+++ b/tests/Http/TurboNativeNavigationControllerTest.php
@@ -39,26 +39,37 @@ class TurboNativeNavigationControllerTest extends TestCase
      */
     public function recede_resume_or_refresh_when_native_or_redirect_when_not_with_flash(string $action)
     {
-        // Non-Turbo Native redirect with flash, but without fragments...
+        // Non-Turbo Native redirect with only flash...
         $this->post(route('trays.store'), ['return_to' => "{$action}_or_redirect", 'with' => true])
-            ->assertRedirect(route('trays.show', 1))
+            ->assertRedirect(route('trays.show', ['tray' => 1]))
             ->assertSessionHas('status', __('Tray created.'));
 
-        // Non-Turbo Native redirect With flash & fragments...
+        // Non-Turbo Native redirect with only flash & fragments...
         $this->post(route('trays.store'), ['return_to' => "{$action}_or_redirect", 'with' => true, 'fragment' => true])
-            ->assertRedirect(route('trays.show', 1).'#newly-created-tray')
+            ->assertRedirect(route('trays.show', ['tray' => 1]).'#newly-created-tray')
             ->assertSessionHas('status', __('Tray created.'));
 
-        // Turbo Native redirect with flash, but without fragments...
+        // Non-Turbo Native redirect with only flash & fragments & queries...
+        $this->post(route('trays.store'), ['return_to' => "{$action}_or_redirect", 'with' => true, 'fragment' => true, 'query' => true])
+            ->assertRedirect(route('trays.show', ['tray' => 1, 'lorem' => 'ipsum']).'#newly-created-tray')
+            ->assertSessionHas('status', __('Tray created.'));
+
+        // Turbo Native redirect with only flash...
         $this->turboNative()
             ->post(route('trays.store'), ['return_to' => "{$action}_or_redirect", 'with' => true])
             ->assertRedirect(route("turbo_{$action}_historical_location", ['status' => urlencode(__('Tray created.'))]))
             ->assertSessionMissing('status');
 
-        // Turbo Native redirect with flash & fragments...
+        // Turbo Native redirect with only flash & fragments...
         $this->turboNative()
             ->post(route('trays.store'), ['return_to' => "{$action}_or_redirect", 'with' => true, 'fragment' => true])
             ->assertRedirect(route("turbo_{$action}_historical_location", ['status' => urlencode(__('Tray created.'))]).'#newly-created-tray')
+            ->assertSessionMissing('status');
+
+        // Turbo Native redirect with only flash & fragments & query...
+        $this->turboNative()
+            ->post(route('trays.store'), ['return_to' => "{$action}_or_redirect", 'with' => true, 'fragment' => true, 'query' => true])
+            ->assertRedirect(route("turbo_{$action}_historical_location", ['lorem' => 'ipsum', 'status' => urlencode(__('Tray created.'))]).'#newly-created-tray')
             ->assertSessionMissing('status');
     }
 

--- a/tests/Http/TurboNativeNavigationControllerTest.php
+++ b/tests/Http/TurboNativeNavigationControllerTest.php
@@ -9,7 +9,7 @@ class TurboNativeNavigationControllerTest extends TestCase
 {
     use InteractsWithTurbo;
 
-    public function actionsDataProvider()
+    public static function actionsDataProvider()
     {
         return [
             ['recede'],
@@ -23,13 +23,44 @@ class TurboNativeNavigationControllerTest extends TestCase
      *
      * @dataProvider actionsDataProvider
      */
-    public function recede_resume_or_refresh_when_native_or_redirect_when_not(string $action)
+    public function recede_resume_or_refresh_when_native_or_redirect_when_not_without_flash(string $action)
     {
         $this->post(route('trays.store'), ['return_to' => "{$action}_or_redirect"])
             ->assertRedirect(route('trays.show', 1));
 
         $this->turboNative()->post(route('trays.store'), ['return_to' => "{$action}_or_redirect"])
             ->assertRedirect(route("turbo_{$action}_historical_location"));
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider actionsDataProvider
+     */
+    public function recede_resume_or_refresh_when_native_or_redirect_when_not_with_flash(string $action)
+    {
+        // Non-Turbo Native redirect with flash, but without fragments...
+        $this->post(route('trays.store'), ['return_to' => "{$action}_or_redirect", 'with' => true])
+            ->assertRedirect(route('trays.show', 1))
+            ->assertSessionHas('status', __('Tray created.'));
+
+        // Non-Turbo Native redirect With flash & fragments...
+        $this->post(route('trays.store'), ['return_to' => "{$action}_or_redirect", 'with' => true, 'fragment' => true])
+            ->assertRedirect(route('trays.show', 1).'#newly-created-tray')
+            ->assertSessionHas('status', __('Tray created.'));
+
+        // Turbo Native redirect with flash, but without fragments...
+        $this->turboNative()
+            ->post(route('trays.store'), ['return_to' => "{$action}_or_redirect", 'with' => true])
+            ->assertRedirect(route("turbo_{$action}_historical_location", ['status' => urlencode(__('Tray created.'))]))
+            ->assertSessionMissing('status');
+
+        // Turbo Native redirect with flash & fragments...
+        $this->turboNative()
+            ->post(route('trays.store'), ['return_to' => "{$action}_or_redirect", 'with' => true, 'fragment' => true])
+            ->assertRedirect(route("turbo_{$action}_historical_location", ['status' => urlencode(__('Tray created.'))]).'#newly-created-tray')
+            ->assertSessionMissing('status');
+
     }
 
     /**

--- a/workbench/app/Http/Controllers/TraysController.php
+++ b/workbench/app/Http/Controllers/TraysController.php
@@ -19,14 +19,24 @@ class TraysController
 
     public function store(Request $request)
     {
-        return match ($request->input('return_to')) {
-            'recede_or_redirect' => $this->recedeOrRedirectTo(route('trays.show', 1)),
-            'resume_or_redirect' => $this->resumeOrRedirectTo(route('trays.show', 1)),
-            'refresh_or_redirect' => $this->refreshOrRedirectTo(route('trays.show', 1)),
-            'recede_or_redirect_back' => $this->recedeOrRedirectBack(route('trays.show', 5)),
-            'resume_or_redirect_back' => $this->resumeOrRedirectBack(route('trays.show', 5)),
-            'refresh_or_redirect_back' => $this->refreshOrRedirectBack(route('trays.show', 5)),
+        $response = match ($request->input('return_to')) {
+            'recede_or_redirect' => $this->recedeOrRedirectTo(route('trays.show', ['tray' => 1])),
+            'resume_or_redirect' => $this->resumeOrRedirectTo(route('trays.show', ['tray' => 1])),
+            'refresh_or_redirect' => $this->refreshOrRedirectTo(route('trays.show', ['tray' => 1])),
+            'recede_or_redirect_back' => $this->recedeOrRedirectBack(route('trays.show', ['tray' => 5])),
+            'resume_or_redirect_back' => $this->resumeOrRedirectBack(route('trays.show', ['tray' => 5])),
+            'refresh_or_redirect_back' => $this->refreshOrRedirectBack(route('trays.show', ['tray' => 5])),
             default => throw new Exception('Missing return_to param to redirect the response.'),
         };
+
+        if ($request->input('with')) {
+            $response = $response->with('status', __('Tray created.'));
+        }
+
+        if ($request->input('fragment')) {
+            $response = $response->withFragment('#newly-created-tray');
+        }
+
+        return $response;
     }
 }

--- a/workbench/app/Http/Controllers/TraysController.php
+++ b/workbench/app/Http/Controllers/TraysController.php
@@ -19,13 +19,17 @@ class TraysController
 
     public function store(Request $request)
     {
+        $query = $request->boolean('query')
+            ? ['lorem' => 'ipsum']
+            : [];
+
         $response = match ($request->input('return_to')) {
-            'recede_or_redirect' => $this->recedeOrRedirectTo(route('trays.show', ['tray' => 1])),
-            'resume_or_redirect' => $this->resumeOrRedirectTo(route('trays.show', ['tray' => 1])),
-            'refresh_or_redirect' => $this->refreshOrRedirectTo(route('trays.show', ['tray' => 1])),
-            'recede_or_redirect_back' => $this->recedeOrRedirectBack(route('trays.show', ['tray' => 5])),
-            'resume_or_redirect_back' => $this->resumeOrRedirectBack(route('trays.show', ['tray' => 5])),
-            'refresh_or_redirect_back' => $this->refreshOrRedirectBack(route('trays.show', ['tray' => 5])),
+            'recede_or_redirect' => $this->recedeOrRedirectTo(route('trays.show', ['tray' => 1] + $query)),
+            'resume_or_redirect' => $this->resumeOrRedirectTo(route('trays.show', ['tray' => 1] + $query)),
+            'refresh_or_redirect' => $this->refreshOrRedirectTo(route('trays.show', ['tray' => 1] + $query)),
+            'recede_or_redirect_back' => $this->recedeOrRedirectBack(route('trays.show', ['tray' => 5] + $query)),
+            'resume_or_redirect_back' => $this->resumeOrRedirectBack(route('trays.show', ['tray' => 5] + $query)),
+            'refresh_or_redirect_back' => $this->refreshOrRedirectBack(route('trays.show', ['tray' => 5] + $query)),
             default => throw new Exception('Missing return_to param to redirect the response.'),
         };
 


### PR DESCRIPTION
### Changed

- Flash messages in Turbo Native redirects should be sent via query strings instead of flashing into the session

---

closes #119 