### PR TITLE
Allow configuring partials path pattern

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -31,6 +31,50 @@ When using this config, the redirection behavior will still happen, but the pack
 
 You may want to split up your views in smaller chunks (aka. "partials"), such as a `comments/_comment.blade.php` to display a comment resource, or `comments/_form.blade.php` to display the form for both creating and updating comments. This allows you to reuse these _partials_ in [Turbo Streams](/docs/{{version}}/turbo-streams).
 
+Alternatively, you may override opt-in to a `{plural}.partials.{singular}` convention for your partials location by calling the `Turbo::usePartialsSubfolderPattern()` method of the Turbo Facade from your `AppServiceProvider::boot()` method:
+
+```php
+<?php
+
+namespace App\Providers;
+
+use HotwiredLaravel\TurboLaravel\Facades\Turbo;
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        Turbo::usePartialsSubfolderPattern();
+    }
+}
+```
+
+You may also want to define your own pattern for partials, which you can do using the `Turbo::resolvePartialsUsing()` method also from the Turbo Facade. This method accepts either a string pattern or a Closure. If you specify a string, you'll have two placefolders available to resolve the pattern `{singular}` and `{plural}`, which will get replaced internally when resolving the pattern. If you specify a Closure, you will receive the model instance and must return a string using the dot notation for view definitions. The placeholders will still be replaced on the resulting string of the Closure. For instance, here's how we could achiave the subfolder pattern manually:
+
+```php
+<?php
+
+namespace App\Providers;
+
+use HotwiredLaravel\TurboLaravel\Facades\Turbo;
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        Turbo::resolvePartialsPathUsing('{plural}.partials.{singular}');
+
+        // Alternatively...
+
+        Turbo::resolvePartialsPathUsing(fn ($model) => 'partials.{singular}');
+    }
+}
+```
+
+You may also want to define your own pattern, which you can do by either specifying a string where you have the `{plural}` and `{singular}` placeholders available, but you can also specify a Closure, which will receive the model instance. On that Closure, you must return a string with the view location using the dot convention of Laravel. For instance, the subfolder pattern sets the config value to `{plural}.partials.{singular}` instead of the default, which is `{plural}._{singular}`. These will resolve to `comments.partials.comment` and `comments._comment` views, respectively.
+
 The models' partials (such as a `comments/_comment.blade.php` for a `Comment` model) may only rely on having a single `$comment` variable passed to them. That's because Turbo Stream Model Broadcasts - which is an _optional_ feature, by the way - relies on these conventions to figure out the partial for a given model when broadcasting and will also pass the model to such partial, using the class basename as the variable instance in _camelCase_. Again, this is optional, you can customize most of these things or create your own model broadcasting convention. Read the [Broadcasting](/docs/{{version}}/broadcasting) section to know more.
 
 ## Turbo Stream Channel Names

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -31,7 +31,7 @@ When using this config, the redirection behavior will still happen, but the pack
 
 You may want to split up your views in smaller chunks (aka. "partials"), such as a `comments/_comment.blade.php` to display a comment resource, or `comments/_form.blade.php` to display the form for both creating and updating comments. This allows you to reuse these _partials_ in [Turbo Streams](/docs/{{version}}/turbo-streams).
 
-Alternatively, you may override opt-in to a `{plural}.partials.{singular}` convention for your partials location by calling the `Turbo::usePartialsSubfolderPattern()` method of the Turbo Facade from your `AppServiceProvider::boot()` method:
+Alternatively, you may override the pattern to a `{plural}.partials.{singular}` convention for your partials location by calling the `Turbo::usePartialsSubfolderPattern()` method of the Turbo Facade from your `AppServiceProvider::boot()` method:
 
 ```php
 <?php
@@ -50,7 +50,7 @@ class AppServiceProvider extends ServiceProvider
 }
 ```
 
-You may also want to define your own pattern for partials, which you can do using the `Turbo::resolvePartialsUsing()` method also from the Turbo Facade. This method accepts either a string pattern or a Closure. If you specify a string, you'll have two placefolders available to resolve the pattern `{singular}` and `{plural}`, which will get replaced internally when resolving the pattern. If you specify a Closure, you will receive the model instance and must return a string using the dot notation for view definitions. The placeholders will still be replaced on the resulting string of the Closure. For instance, here's how we could achiave the subfolder pattern manually:
+You may also want to define your own pattern for partials, which you can do using the `Turbo::resolvePartialsUsing()` method. This method accepts either a string pattern or a Closure. If you pass a string pattern, you'll have two replaceholders available: `{singular}` and `{plural}`, which will get replaced with the model's singular and plural names, respectively, when the pattern is used. If you pass a Closure, you'll have the model instance available and you must return the view pattern using Laravel's dot notation convention. The pattern returned from the Closure will also get the placeholders applied, if you need that. Here's how you could manually define the partials subfolder pattern:
 
 ```php
 <?php
@@ -66,7 +66,7 @@ class AppServiceProvider extends ServiceProvider
     {
         Turbo::resolvePartialsPathUsing('{plural}.partials.{singular}');
 
-        // Alternatively...
+        // Or...
 
         Turbo::resolvePartialsPathUsing(fn ($model) => 'partials.{singular}');
     }

--- a/src/Facades/Turbo.php
+++ b/src/Facades/Turbo.php
@@ -4,6 +4,7 @@ namespace HotwiredLaravel\TurboLaravel\Facades;
 
 use Closure;
 use HotwiredLaravel\TurboLaravel\Broadcasters\Broadcaster;
+use HotwiredLaravel\TurboLaravel\NamesResolver;
 use HotwiredLaravel\TurboLaravel\Turbo as BaseTurbo;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Facade;
@@ -31,7 +32,7 @@ class Turbo extends Facade
 
     public static function resolvePartialsPathUsing(string|Closure $pattern)
     {
-        config()->set('turbo-laravel.partials_path', $pattern);
+        NamesResolver::resolvePartialsPathUsing($pattern);
     }
 
     protected static function getFacadeAccessor()

--- a/src/Facades/Turbo.php
+++ b/src/Facades/Turbo.php
@@ -2,6 +2,7 @@
 
 namespace HotwiredLaravel\TurboLaravel\Facades;
 
+use Closure;
 use HotwiredLaravel\TurboLaravel\Broadcasters\Broadcaster;
 use HotwiredLaravel\TurboLaravel\Turbo as BaseTurbo;
 use Illuminate\Database\Eloquent\Model;
@@ -23,6 +24,16 @@ use Illuminate\Support\Facades\Facade;
  */
 class Turbo extends Facade
 {
+    public static function usePartialsSubfolderPattern()
+    {
+        static::resolvePartialsPathUsing('{plural}.partials.{singular}');
+    }
+
+    public static function resolvePartialsPathUsing(string|Closure $pattern)
+    {
+        config()->set('turbo-laravel.partials_path', $pattern);
+    }
+
     protected static function getFacadeAccessor()
     {
         return BaseTurbo::class;

--- a/src/NamesResolver.php
+++ b/src/NamesResolver.php
@@ -2,12 +2,20 @@
 
 namespace HotwiredLaravel\TurboLaravel;
 
+use Closure;
 use HotwiredLaravel\TurboLaravel\Models\Naming\Name;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
 class NamesResolver
 {
+    protected static $partialsPathResolver = '{plural}._{singular}';
+
+    public static function resolvePartialsPathUsing(string|Closure $resolver)
+    {
+        static::$partialsPathResolver = $resolver;
+    }
+
     public static function resourceVariableName(Model $model): string
     {
         return Str::camel(Name::forModel($model)->singular);
@@ -22,7 +30,7 @@ class NamesResolver
             '{singular}' => $name->element,
         ];
 
-        $pattern = config('turbo-laravel.partials_path', '{plural}._{singular}');
+        $pattern = value(static::$partialsPathResolver, $model);
 
         return str_replace(array_keys($replacements), array_values($replacements), value($pattern, $model));
     }

--- a/src/NamesResolver.php
+++ b/src/NamesResolver.php
@@ -17,9 +17,13 @@ class NamesResolver
     {
         $name = Name::forModel($model);
 
-        $resource = $name->plural;
-        $partial = $name->element;
+        $replacements = [
+            '{plural}' => $name->plural,
+            '{singular}' => $name->element,
+        ];
 
-        return "{$resource}._{$partial}";
+        $pattern = config('turbo-laravel.partials_path', '{plural}._{singular}');
+
+        return str_replace(array_keys($replacements), array_values($replacements), value($pattern, $model));
     }
 }

--- a/tests/Models/NamesResolverTest.php
+++ b/tests/Models/NamesResolverTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace HotwiredLaravel\TurboLaravel\Tests\Models;
+
+use HotwiredLaravel\TurboLaravel\Facades\Turbo;
+use HotwiredLaravel\TurboLaravel\NamesResolver;
+use HotwiredLaravel\TurboLaravel\Tests\TestCase;
+use Illuminate\Database\Eloquent\Model;
+use Workbench\Database\Factories\ArticleFactory;
+
+class NamesResolverTest extends TestCase
+{
+    /** @test */
+    public function resolves_partial_naming()
+    {
+        $article = ArticleFactory::new()->make();
+
+        $this->assertEquals('articles._article', NamesResolver::partialNameFor($article));
+    }
+
+    /** @test */
+    public function resolves_partial_naming_using_subfolder()
+    {
+        $article = ArticleFactory::new()->make();
+
+        Turbo::usePartialsSubfolderPattern();
+
+        $this->assertEquals('articles.partials.article', NamesResolver::partialNameFor($article));
+    }
+
+    /** @test */
+    public function resolves_using_custom_closure()
+    {
+        $article = ArticleFactory::new()->make();
+
+        Turbo::resolvePartialsPathUsing(fn (Model $model) => 'partials.article');
+
+        $this->assertEquals('partials.article', NamesResolver::partialNameFor($article));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace HotwiredLaravel\TurboLaravel\Tests;
 
+use HotwiredLaravel\TurboLaravel\Facades\Turbo;
 use HotwiredLaravel\TurboLaravel\Facades\TurboStream;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Orchestra\Testbench\Concerns\WithWorkbench;
@@ -17,6 +18,7 @@ class TestCase extends Orchestra
         parent::setUp();
 
         TurboStream::fake();
+        Turbo::resolvePartialsPathUsing('{plural}._{singular}');
     }
 
     protected function defineEnvironment($app)


### PR DESCRIPTION
### Changed

- Allows configuring the partials path pattern. Until now, the partials path pattern was hardcoded to `{plural}._{singular}`, but with these opt-in changes, we can now define it to `{plural}.partials.{singular}` or any other pattern you want to set.

---

closes #135 