### PR TITLE
feat: improve skill scores for turbo-laravel

### DIFF
--- a/resources/boost/skills/developing-with-turbo-basics/SKILL.md
+++ b/resources/boost/skills/developing-with-turbo-basics/SKILL.md
@@ -1,33 +1,11 @@
 ---
 name: developing-with-turbo-basics
-description: >-
-  Basics of developing with Turbo Laravel. Activates when starting a new Turbo Laravel project; using dom_id, dom_class,
-  turbo_stream(), or turbo_stream_view() helpers; working with Blade components like x-turbo::frame, x-turbo::stream,
-  x-turbo::stream-from, or x-turbo::refreshes-with; using @domid, @domclass, @channel, or @turbonative directives;
-  checking wantsTurboStream(), wasFromTurboFrame(), or wasFromHotwireNative() request macros; or when the user mentions
-  Hotwire, Turbo, HTML over the wire, or partial page updates.
+description: "Implements Turbo Streams, configures Turbo Frames, and integrates Hotwire patterns in Laravel applications. Activates when starting a new Turbo Laravel project; using dom_id, dom_class, turbo_stream(), or turbo_stream_view() helpers; working with Blade components like x-turbo::frame, x-turbo::stream, x-turbo::stream-from, or x-turbo::refreshes-with; using @domid, @domclass, @channel, or @turbonative directives; checking wantsTurboStream(), wasFromTurboFrame(), or wasFromHotwireNative() request macros; or when the user mentions Hotwire, Turbo, HTML over the wire, or partial page updates."
 ---
 
 # Turbo Laravel Basics
 
 Turbo Laravel is a package that integrates Turbo, a set of technologies for building modern web applications, with the Laravel framework. Turbo enhances user experience by enabling partial page updates, real-time interactions, and seamless navigation without full page reloads and with minimal JavaScript.
-
-## Philosophy: HTML Over the Wire
-
-Hotwire (HTML Over the Wire) sends HTML instead of JSON from the server, letting the server handle rendering while keeping the browser's job simple. It combines four techniques:
-
-1. **Turbo Drive** — Accelerates links and forms by replacing the `<body>` without full page loads.
-2. **Turbo Frames** — Decomposes pages into independent segments that scope navigation and can lazy-load.
-3. **Turbo Streams** — Delivers partial page changes over WebSocket, SSE, or in response to form submissions using eight actions (append, prepend, replace, update, remove, before, after, refresh).
-4. **Stimulus** — A modest JavaScript framework for the HTML you already have, connecting behavior via `data-controller`, `data-action`, and `data-target` attributes.
-
-Turbo Laravel provides the server-side tooling (Blade components, helpers, broadcasting, and testing utilities) to make these techniques work seamlessly with Laravel.
-
-## Turbo Drive
-
-Turbo Drive intercepts all clicks on `<a href>` links to the same domain and all form submissions, turning them into `fetch` requests. It replaces the `<body>` and merges the `<head>`, keeping the JavaScript `window` and `document` objects persistent across navigations. This gives SPA-like speed without client-side routing.
-
-Same deal with forms — their submissions become fetch requests and Turbo Drive follows the redirect and renders the HTML response.
 
 IMPORTANT: Activate the `developing-with-turbo-drive` skill when starting out working on a feature.
 

--- a/resources/boost/skills/developing-with-turbo-drive/SKILL.md
+++ b/resources/boost/skills/developing-with-turbo-drive/SKILL.md
@@ -1,27 +1,16 @@
 ---
 name: developing-with-turbo-drive
-description: >-
-  Develops with Turbo Drive for SPA-like navigation. Activates when configuring page morphing with x-turbo::refreshes-with;
-  working with data-turbo, data-turbo-track, data-turbo-permanent, or data-turbo-preload attributes; managing cache control
-  with x-turbo::exempts-page-from-cache, x-turbo::exempts-page-from-preview, or x-turbo::page-requires-reload; enabling
-  view transitions with x-turbo::page-view-transition; handling form redirects with TurboMiddleware; customizing the progress
-  bar; or when the user mentions Turbo Drive, navigation, page morphing, prefetching, or asset tracking.
+description: "Develops with Turbo Drive for SPA-like navigation. Activates when configuring page morphing with x-turbo::refreshes-with; working with data-turbo, data-turbo-track, data-turbo-permanent, or data-turbo-preload attributes; managing cache control with x-turbo::exempts-page-from-cache, x-turbo::exempts-page-from-preview, or x-turbo::page-requires-reload; enabling view transitions with x-turbo::page-view-transition; handling form redirects with TurboMiddleware; customizing the progress bar; or when the user mentions Turbo Drive, navigation, page morphing, prefetching, or asset tracking."
 ---
 
 # Turbo Drive
 
-Turbo Drive accelerates navigation by intercepting link clicks and form submissions, making them as `fetch` requests. It replaces the `<body>` and merges the `<head>` without tearing down the JavaScript environment, giving SPA-like speed with server-rendered HTML.
-
-## How It Works
-
-- **Link clicks**: Turbo intercepts clicks on `<a href>` links to the same domain, updates the URL via the History API, fetches the new page, and renders the HTML response.
-- **Form submissions**: Form submissions become `fetch` requests. Turbo follows the redirect and renders the response.
-- **Rendering**: Replaces `<body>`, merges `<head>`. The `window`, `document`, and `<html>` element persist across navigations.
+Turbo Drive intercepts link clicks and form submissions as `fetch` requests, replacing the `<body>` and merging the `<head>` while keeping the JavaScript environment persistent.
 
 ## Navigation Types
 
-- **Application Visits** (advance/replace): Initiated by clicking a link or calling `Turbo.visit()`. Issues a fetch, renders HTML. Advance pushes to history; replace modifies the current entry.
-- **Restoration Visits**: Triggered by the browser Back/Forward buttons. Turbo restores from cache if available, otherwise fetches fresh content.
+- **Application Visits** (advance/replace): Initiated by clicking a link or calling `Turbo.visit()`. Advance pushes to history; replace modifies the current entry.
+- **Restoration Visits**: Triggered by Back/Forward buttons. Restores from cache if available, otherwise fetches fresh content.
 
 ## Page Refreshes with Morphing
 

--- a/resources/boost/skills/developing-with-turbo-frames/SKILL.md
+++ b/resources/boost/skills/developing-with-turbo-frames/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: developing-with-turbo-frames
-description: >-
-  Develops with Turbo Frames for scoped navigation and lazy loading. Activates when using the x-turbo::frame Blade
-  component or turbo-frame HTML element; working with data-turbo-frame targeting, frame lazy loading via src attribute,
-  or data-turbo-action for URL updates; detecting frame requests with wasFromTurboFrame(); using frame morphing with
-  refresh="morph"; or when the user mentions Turbo Frame, turbo frame, scoped navigation, inline editing, lazy loading
-  frames, or breaking out of a frame with _top.
+description: "Develops with Turbo Frames for scoped navigation and lazy loading. Activates when using the x-turbo::frame Blade component or turbo-frame HTML element; working with data-turbo-frame targeting, frame lazy loading via src attribute, or data-turbo-action for URL updates; detecting frame requests with wasFromTurboFrame(); using frame morphing with refresh=\"morph\"; or when the user mentions Turbo Frame, turbo frame, scoped navigation, inline editing, lazy loading frames, or breaking out of a frame with _top."
 ---
 
 # Turbo Frames
 
 Turbo Frames decompose pages into independent segments that scope navigation. Clicking links or submitting forms inside a `<turbo-frame>` only updates that frame, keeping the rest of the page intact.
+
+## Quick Start
+
+1. Add a `<x-turbo::frame>` to your show/index view wrapping the content to scope
+2. Create the corresponding edit/detail view with a matching `<x-turbo::frame>` using the same `:id`
+3. Links and forms inside the frame automatically target that frame
+4. On the server, detect frame requests with `$request->wasFromTurboFrame()` to return frame-only responses
+
+IMPORTANT: The frame `id` must match between the source and destination pages. A mismatch causes Turbo to log a console error and leave the frame unchanged.
 
 ## The Frame Component
 

--- a/resources/boost/skills/developing-with-turbo-streams/SKILL.md
+++ b/resources/boost/skills/developing-with-turbo-streams/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: developing-with-turbo-streams
-description: >-
-  Develops with Turbo Streams for partial page updates and real-time broadcasting. Activates when using turbo_stream() or
-  turbo_stream_view() helpers; working with stream actions like append, prepend, replace, update, remove, before, after,
-  or refresh; using the Broadcasts trait, broadcastAppend, broadcastPrepend, broadcastReplace, broadcastRemove, or
-  broadcastRefresh methods; listening with x-turbo::stream-from; using the TurboStream facade for handmade broadcasts;
-  combining multiple streams; or when the user mentions Turbo Stream, broadcasting, real-time updates, WebSocket streams,
-  or partial page changes.
+description: "Develops with Turbo Streams for partial page updates and real-time broadcasting. Activates when using turbo_stream() or turbo_stream_view() helpers; working with stream actions like append, prepend, replace, update, remove, before, after, or refresh; using the Broadcasts trait, broadcastAppend, broadcastPrepend, broadcastReplace, broadcastRemove, or broadcastRefresh methods; listening with x-turbo::stream-from; using the TurboStream facade for handmade broadcasts; combining multiple streams; or when the user mentions Turbo Stream, broadcasting, real-time updates, WebSocket streams, or partial page changes."
 ---
 
 # Turbo Streams
 
 Turbo Streams let you change any part of the page using eight actions: `append`, `prepend`, `replace`, `update`, `remove`, `before`, `after`, and `refresh`. They work as HTTP responses (after form submissions) and as real-time broadcasts over WebSocket.
+
+## Quick Start
+
+1. Check `$request->wantsTurboStream()` in your controller to detect Turbo Stream requests
+2. Return `turbo_stream($model)` for auto-detected actions (created=append, updated=replace, deleted=remove)
+3. For broadcasting: add `use Broadcasts` trait to your model, set `protected $broadcasts = true`
+4. In views, add `<x-turbo::stream-from :source="$model" />` to listen for broadcasts
+5. Define channel authorization in `routes/channels.php`
+
+IMPORTANT: If broadcasts aren't received, verify channel auth in `routes/channels.php`, confirm Laravel Echo is configured, and check the WebSocket connection in browser dev tools.
 
 ## HTTP Turbo Streams
 

--- a/resources/boost/skills/developing-with-turbo-tests/SKILL.md
+++ b/resources/boost/skills/developing-with-turbo-tests/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: developing-with-turbo-tests
-description: >-
-  Tests Turbo Laravel features in PHPUnit or Pest. Activates when using the InteractsWithTurbo trait; simulating requests with
-  $this->turbo(), $this->fromTurboFrame(), or $this->hotwireNative(); asserting responses with assertTurboStream(),
-  assertNotTurboStream(), assertRedirectRecede(), assertRedirectResume(), or assertRedirectRefresh(); faking broadcasts
-  with TurboStream::fake(), assertBroadcasted(), assertNothingWasBroadcasted(), or assertBroadcastedTimes(); writing
-  feature tests for Turbo Stream responses; or when the user mentions testing Turbo, testing broadcasts, or Turbo test
-  assertions.
+description: "Tests Turbo Laravel features in PHPUnit or Pest. Activates when using the InteractsWithTurbo trait; simulating requests with $this->turbo(), $this->fromTurboFrame(), or $this->hotwireNative(); asserting responses with assertTurboStream(), assertNotTurboStream(), assertRedirectRecede(), assertRedirectResume(), or assertRedirectRefresh(); faking broadcasts with TurboStream::fake(), assertBroadcasted(), assertNothingWasBroadcasted(), or assertBroadcastedTimes(); writing feature tests for Turbo Stream responses; or when the user mentions testing Turbo, testing broadcasts, or Turbo test assertions."
 ---
 
 # Testing Turbo Laravel
@@ -210,3 +204,8 @@ TurboStream::assertBroadcastedTimes(
 </code-snippet>
 
 @endverbatim
+
+## Troubleshooting
+
+- **`assertTurboStream()` fails**: Inspect the response with `$response->getContent()` to see the actual HTML returned. Verify the controller checks `$request->wantsTurboStream()` and returns a Turbo Stream response.
+- **Broadcast assertions fail**: Ensure `TurboStream::fake()` is called before the action that triggers the broadcast. Check that the model uses the `Broadcasts` trait and has `$broadcasts = true` or calls broadcast methods explicitly.


### PR DESCRIPTION
Hullo @tonysm 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| developing-with-turbo-basics | 81% | 86% | +5% | 
| developing-with-turbo-drive | 89% | 90% | +1% |
| developing-with-turbo-frames | 90% | 96% | +6% | 
| developing-with-turbo-streams | 90% | 96% | +6% | 
| developing-with-turbo-tests | 94% | 94% | — |

<details>
<summary>Changes made</summary>

**All skills**
- Converted frontmatter description from YAML chevron to standard quoted string format for better tooling compatibility

**developing-with-turbo-basics** (+5%)
- Replaced vague "Basics of developing with Turbo Laravel" opening with specific actions: "Implements Turbo Streams, configures Turbo Frames, and integrates Hotwire patterns"
- Removed conceptual "Philosophy: HTML Over the Wire" section — Claude already understands these concepts, and this was adding ~100 tokens of non-actionable context
- Trimmed the Turbo Drive explanation down to just the IMPORTANT callout directing to the sub-skill

**developing-with-turbo-drive** (+1%)
- Condensed the introductory paragraph and "How It Works" section — removed explanations of fetch requests, History API, and DOM replacement that Claude already knows
- Trimmed Navigation Types to focus on Turbo-specific behaviors only

**developing-with-turbo-frames** (+6%)
- Added a "Quick Start" workflow section with a clear 4-step implementation sequence
- Added an IMPORTANT callout about frame ID matching (a common pitfall that causes silent failures)

**developing-with-turbo-streams** (+6%)
- Added a "Quick Start" workflow section with a 5-step sequence covering both HTTP streams and broadcasting setup
- Added an IMPORTANT troubleshooting callout for when broadcasts aren't received (channel auth, Echo config, WebSocket connection)

**developing-with-turbo-tests** (no change)
- Added a Troubleshooting section for assertTurboStream() and broadcast assertion failures — score held steady at 94% as this was already high-quality

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - @popey - if you hit any snags.

Thanks in advance 🙏